### PR TITLE
Support 'none' as key exchange, cipher, crypto, and auth algorithms

### DIFF
--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -45,6 +45,8 @@ pub const RSA_SHA2_512: Name = Name("rsa-sha2-512");
 /// The name of the ssh-sha2-256 algorithm for SSH.
 pub const RSA_SHA2_256: Name = Name("rsa-sha2-256");
 
+pub const NONE: Name = Name("none");
+
 pub const SSH_RSA: Name = Name("ssh-rsa");
 
 impl Name {

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -94,7 +94,7 @@ impl<R: AsyncRead + AsyncWrite + Unpin + Send + 'static> Signer
 
 #[derive(Debug)]
 pub enum Method {
-    // None,
+    None,
     Password { password: String },
     PublicKey { key: Arc<key::KeyPair> },
     FuturePublicKey { key: key::PublicKey },

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -66,6 +66,7 @@ pub const AES_192_CTR: Name = Name("aes192-ctr");
 pub const AES_256_CTR: Name = Name("aes256-ctr");
 pub const AES_256_GCM: Name = Name("aes256-gcm@openssh.com");
 pub const CHACHA20_POLY1305: Name = Name("chacha20-poly1305@openssh.com");
+pub const NONE: Name = Name("none");
 
 static _CLEAR: Clear = Clear {};
 static _AES_128_CTR: SshBlockCipher<Ctr128BE<Aes128>> = SshBlockCipher(PhantomData);
@@ -77,6 +78,7 @@ static _CHACHA20_POLY1305: SshChacha20Poly1305Cipher = SshChacha20Poly1305Cipher
 pub static CIPHERS: Lazy<HashMap<&'static Name, &(dyn Cipher + Send + Sync)>> = Lazy::new(|| {
     let mut h: HashMap<&'static Name, &(dyn Cipher + Send + Sync)> = HashMap::new();
     h.insert(&CLEAR, &_CLEAR);
+    h.insert(&NONE, &_CLEAR);
     h.insert(&AES_128_CTR, &_AES_128_CTR);
     h.insert(&AES_192_CTR, &_AES_192_CTR);
     h.insert(&AES_256_CTR, &_AES_256_CTR);

--- a/russh/src/kex/curve25519.rs
+++ b/russh/src/kex/curve25519.rs
@@ -38,6 +38,10 @@ impl std::fmt::Debug for Curve25519Kex {
 // that curve is controversial, see
 // http://safecurves.cr.yp.to/rigid.html
 impl KexAlgorithm for Curve25519Kex {
+    fn skip_exchange(&self) -> bool {
+        false
+    }
+
     #[doc(hidden)]
     fn server_dh(&mut self, exchange: &mut Exchange, payload: &[u8]) -> Result<(), crate::Error> {
         debug!("server_dh");

--- a/russh/src/kex/dh/mod.rs
+++ b/russh/src/kex/dh/mod.rs
@@ -77,6 +77,10 @@ fn biguint_to_mpint(biguint: &BigUint) -> Vec<u8> {
 }
 
 impl<D: Digest> KexAlgorithm for DhGroupKex<D> {
+    fn skip_exchange(&self) -> bool {
+        false
+    }
+
     #[doc(hidden)]
     fn server_dh(&mut self, exchange: &mut Exchange, payload: &[u8]) -> Result<(), crate::Error> {
         debug!("server_dh");

--- a/russh/src/kex/mod.rs
+++ b/russh/src/kex/mod.rs
@@ -14,6 +14,7 @@
 //
 mod curve25519;
 mod dh;
+mod none;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -41,6 +42,8 @@ impl Debug for dyn KexAlgorithm + Send {
 }
 
 pub trait KexAlgorithm {
+    fn skip_exchange(&self) -> bool;
+
     fn server_dh(&mut self, exchange: &mut Exchange, payload: &[u8]) -> Result<(), crate::Error>;
 
     fn client_dh(
@@ -81,10 +84,12 @@ pub const CURVE25519: Name = Name("curve25519-sha256@libssh.org");
 pub const DH_G1_SHA1: Name = Name("diffie-hellman-group1-sha1");
 pub const DH_G14_SHA1: Name = Name("diffie-hellman-group14-sha1");
 pub const DH_G14_SHA256: Name = Name("diffie-hellman-group14-sha256");
+pub const NONE: Name = Name("none");
 const _CURVE25519: Curve25519KexType = Curve25519KexType {};
 const _DH_G1_SHA1: DhGroup1Sha1KexType = DhGroup1Sha1KexType {};
 const _DH_G14_SHA1: DhGroup14Sha1KexType = DhGroup14Sha1KexType {};
 const _DH_G14_SHA256: DhGroup14Sha256KexType = DhGroup14Sha256KexType {};
+const _NONE: none::NoneKexType = none::NoneKexType {};
 
 pub static KEXES: Lazy<HashMap<&'static Name, &(dyn KexType + Send + Sync)>> = Lazy::new(|| {
     let mut h: HashMap<&'static Name, &(dyn KexType + Send + Sync)> = HashMap::new();
@@ -92,6 +97,7 @@ pub static KEXES: Lazy<HashMap<&'static Name, &(dyn KexType + Send + Sync)>> = L
     h.insert(&DH_G14_SHA256, &_DH_G14_SHA256);
     h.insert(&DH_G14_SHA1, &_DH_G14_SHA1);
     h.insert(&DH_G1_SHA1, &_DH_G1_SHA1);
+    h.insert(&NONE, &_NONE);
     h
 });
 

--- a/russh/src/kex/none.rs
+++ b/russh/src/kex/none.rs
@@ -1,0 +1,68 @@
+use russh_cryptovec::CryptoVec;
+
+use super::{KexAlgorithm, KexType};
+
+pub struct NoneKexType {}
+
+impl KexType for NoneKexType {
+    fn make(&self) -> Box<dyn KexAlgorithm + Send> {
+        Box::new(NoneKexAlgorithm {}) as Box<dyn KexAlgorithm + Send>
+    }
+}
+
+struct NoneKexAlgorithm {}
+
+impl KexAlgorithm for NoneKexAlgorithm {
+    fn skip_exchange(&self) -> bool {
+        true
+    }
+
+    fn server_dh(
+        &mut self,
+        _exchange: &mut crate::session::Exchange,
+        _payload: &[u8],
+    ) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    fn client_dh(
+        &mut self,
+        _client_ephemeral: &mut russh_cryptovec::CryptoVec,
+        _buf: &mut russh_cryptovec::CryptoVec,
+    ) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    fn compute_shared_secret(&mut self, _remote_pubkey: &[u8]) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    fn compute_exchange_hash(
+        &self,
+        _key: &russh_cryptovec::CryptoVec,
+        _exchange: &crate::session::Exchange,
+        _buffer: &mut russh_cryptovec::CryptoVec,
+    ) -> Result<russh_cryptovec::CryptoVec, crate::Error> {
+        Ok(CryptoVec::new())
+    }
+
+    fn compute_keys(
+        &self,
+        session_id: &russh_cryptovec::CryptoVec,
+        exchange_hash: &russh_cryptovec::CryptoVec,
+        cipher: crate::cipher::Name,
+        remote_to_local_mac: crate::mac::Name,
+        local_to_remote_mac: crate::mac::Name,
+        is_server: bool,
+    ) -> Result<crate::cipher::CipherPair, crate::Error> {
+        super::compute_keys::<sha2::Sha256>(
+            None,
+            session_id,
+            exchange_hash,
+            cipher,
+            remote_to_local_mac,
+            local_to_remote_mac,
+            is_server,
+        )
+    }
+}

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -130,7 +130,7 @@ impl Session {
         let mut enc = self.common.encrypted.as_mut().unwrap();
         // If we've successfully read a packet.
         match enc.state {
-            EncryptedState::WaitingServiceRequest {
+            EncryptedState::WaitingAuthServiceRequest {
                 ref mut accepted, ..
             } if buf.get(0) == Some(&msg::SERVICE_REQUEST) => {
                 let mut r = buf.reader(1);

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -702,7 +702,7 @@ async fn reply<H: Handler>(
                 }
                 // Ok, NEWKEYS received, now encrypted.
                 session.common.encrypted(
-                    EncryptedState::WaitingServiceRequest {
+                    EncryptedState::WaitingAuthServiceRequest {
                         sent: false,
                         accepted: false,
                     },

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -381,7 +381,7 @@ impl Encrypted {
 
 #[derive(Debug)]
 pub enum EncryptedState {
-    WaitingServiceRequest { sent: bool, accepted: bool },
+    WaitingAuthServiceRequest { sent: bool, accepted: bool },
     WaitingAuthRequest(auth::AuthRequest),
     InitCompression,
     Authenticated,


### PR DESCRIPTION
While not technically optional in the SSH specification, we have a slightly esoteric scenario where the key exchange is skipped via the kex algorithm being presented as `none` (and `none` authentication is also used).

This PR adds support for those, although it doesn't add them as any Preferred default, as any use of them should be _very_ intentional.