### PR TITLE
Allow vendoring openssl

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -63,6 +63,9 @@ tokio = { version = "1.17.0", features = [
 tokio-stream = { version = "0.1", features = ["net"] }
 yasna = { version = "0.4.0", features = ["bit-vec", "num-bigint"] }
 
+[features]
+vendored-openssl = ["openssl", "openssl/vendored"]
+
 [dev-dependencies]
 env_logger = "0.8"
 tempdir = "0.3"

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.34.0-beta.8"
 
 [features]
 default = ["flate2"]
+vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dependencies]
 aes = "0.8"


### PR DESCRIPTION
This adds a `vendored-openssl` feature that will have the crate use the vendored version of OpenSSL rather than dynamically linking it.