### PR TITLE
initial support bidirectional, server-initiated channels

### DIFF
--- a/russh/src/channels.rs
+++ b/russh/src/channels.rs
@@ -1,0 +1,335 @@
+use russh_cryptovec::CryptoVec;
+use tokio::sync::mpsc::{Sender, UnboundedReceiver};
+
+use crate::{ChannelId, Error, Pty, Sig};
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ChannelMsg {
+    Open {
+        id: ChannelId,
+        max_packet_size: u32,
+        window_size: u32,
+    },
+    Data {
+        data: CryptoVec,
+    },
+    ExtendedData {
+        data: CryptoVec,
+        ext: u32,
+    },
+    Eof,
+    /// (client only)
+    RequestPty {
+        want_reply: bool,
+        term: String,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        terminal_modes: Vec<(Pty, u32)>,
+    },
+    /// (client only)
+    RequestShell {
+        want_reply: bool,
+    },
+    /// (client only)
+    Exec {
+        want_reply: bool,
+        command: String,
+    },
+    /// (client only)
+    Signal {
+        signal: Sig,
+    },
+    /// (client only)
+    RequestSubsystem {
+        want_reply: bool,
+        name: String,
+    },
+    /// (client only)
+    RequestX11 {
+        want_reply: bool,
+        single_connection: bool,
+        x11_authentication_protocol: String,
+        x11_authentication_cookie: String,
+        x11_screen_number: u32,
+    },
+    /// (client only)
+    SetEnv {
+        want_reply: bool,
+        variable_name: String,
+        variable_value: String,
+    },
+    /// (client only)
+    WindowChange {
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+    },
+
+    /// (server only)
+    XonXoff {
+        client_can_do: bool,
+    },
+    /// (server only)
+    ExitStatus {
+        exit_status: u32,
+    },
+    /// (server only)
+    ExitSignal {
+        signal_name: Sig,
+        core_dumped: bool,
+        error_message: String,
+        lang_tag: String,
+    },
+    /// (server only)
+    WindowAdjusted {
+        new_size: u32,
+    },
+    /// (server only)
+    Success,
+    /// (server only)
+    Close,
+}
+
+pub struct Channel<Send: From<(ChannelId, ChannelMsg)>> {
+    pub(crate) id: ChannelId,
+    pub(crate) sender: Sender<Send>,
+    pub(crate) receiver: UnboundedReceiver<ChannelMsg>,
+    pub(crate) max_packet_size: u32,
+    pub(crate) window_size: u32,
+}
+
+impl<Send: From<(ChannelId, ChannelMsg)>> Channel<Send> {
+    pub fn id(&self) -> ChannelId {
+        self.id
+    }
+
+    /// Returns the min between the maximum packet size and the
+    /// remaining window size in the channel.
+    pub fn writable_packet_size(&self) -> usize {
+        self.max_packet_size.min(self.window_size) as usize
+    }
+
+    /// Request a pseudo-terminal with the given characteristics.
+    #[allow(clippy::too_many_arguments)] // length checked
+    pub async fn request_pty(
+        &mut self,
+        want_reply: bool,
+        term: &str,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        terminal_modes: &[(Pty, u32)],
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestPty {
+            want_reply,
+            term: term.to_string(),
+            col_width,
+            row_height,
+            pix_width,
+            pix_height,
+            terminal_modes: terminal_modes.to_vec(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Request a remote shell.
+    pub async fn request_shell(&mut self, want_reply: bool) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestShell { want_reply })
+            .await?;
+        Ok(())
+    }
+
+    /// Execute a remote program (will be passed to a shell). This can
+    /// be used to implement scp (by calling a remote scp and
+    /// tunneling to its standard input).
+    pub async fn exec<A: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        command: A,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::Exec {
+            want_reply,
+            command: command.into(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Signal a remote process.
+    pub async fn signal(&mut self, signal: Sig) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::Signal { signal }).await?;
+        Ok(())
+    }
+
+    /// Request the start of a subsystem with the given name.
+    pub async fn request_subsystem<A: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        name: A,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestSubsystem {
+            want_reply,
+            name: name.into(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Request X11 forwarding through an already opened X11
+    /// channel. See
+    /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-6.3.1)
+    /// for security issues related to cookies.
+    pub async fn request_x11<A: Into<String>, B: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        single_connection: bool,
+        x11_authentication_protocol: A,
+        x11_authentication_cookie: B,
+        x11_screen_number: u32,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::RequestX11 {
+            want_reply,
+            single_connection,
+            x11_authentication_protocol: x11_authentication_protocol.into(),
+            x11_authentication_cookie: x11_authentication_cookie.into(),
+            x11_screen_number,
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Set a remote environment variable.
+    pub async fn set_env<A: Into<String>, B: Into<String>>(
+        &mut self,
+        want_reply: bool,
+        variable_name: A,
+        variable_value: B,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::SetEnv {
+            want_reply,
+            variable_name: variable_name.into(),
+            variable_value: variable_value.into(),
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Inform the server that our window size has changed.
+    pub async fn window_change(
+        &mut self,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+    ) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::WindowChange {
+            col_width,
+            row_height,
+            pix_width,
+            pix_height,
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Send data to a channel.
+    pub async fn data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+        &mut self,
+        data: R,
+    ) -> Result<(), Error> {
+        self.send_data(None, data).await
+    }
+
+    /// Send data to a channel. The number of bytes added to the
+    /// "sending pipeline" (to be processed by the event loop) is
+    /// returned.
+    pub async fn extended_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+        &mut self,
+        ext: u32,
+        data: R,
+    ) -> Result<(), Error> {
+        self.send_data(Some(ext), data).await
+    }
+
+    async fn send_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+        &mut self,
+        ext: Option<u32>,
+        mut data: R,
+    ) -> Result<(), Error> {
+        let mut total = 0;
+        loop {
+            // wait for the window to be restored.
+            while self.window_size == 0 {
+                match self.receiver.recv().await {
+                    Some(ChannelMsg::WindowAdjusted { new_size }) => {
+                        debug!("window adjusted: {:?}", new_size);
+                        self.window_size = new_size;
+                        break;
+                    }
+                    Some(msg) => {
+                        debug!("unexpected channel msg: {:?}", msg);
+                    }
+                    None => break,
+                }
+            }
+            debug!(
+                "sending data, self.window_size = {:?}, self.max_packet_size = {:?}, total = {:?}",
+                self.window_size, self.max_packet_size, total
+            );
+            let sendable = self.window_size.min(self.max_packet_size) as usize;
+            debug!("sendable {:?}", sendable);
+            let mut c = CryptoVec::new_zeroed(sendable);
+            let n = data.read(&mut c[..]).await?;
+            total += n;
+            c.resize(n);
+            self.window_size -= n as u32;
+            self.send_data_packet(ext, c).await?;
+            if n == 0 {
+                break;
+            } else if self.window_size > 0 {
+                continue;
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_data_packet(&mut self, ext: Option<u32>, data: CryptoVec) -> Result<(), Error> {
+        self.send_msg(if let Some(ext) = ext {
+            ChannelMsg::ExtendedData { ext, data }
+        } else {
+            ChannelMsg::Data { data }
+        })
+        .await?;
+        Ok(())
+    }
+
+    pub async fn eof(&mut self) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::Eof).await?;
+        Ok(())
+    }
+
+    /// Wait for data to come.
+    pub async fn wait(&mut self) -> Option<ChannelMsg> {
+        match self.receiver.recv().await {
+            Some(ChannelMsg::WindowAdjusted { new_size }) => {
+                self.window_size += new_size;
+                Some(ChannelMsg::WindowAdjusted { new_size })
+            }
+            Some(msg) => Some(msg),
+            None => None,
+        }
+    }
+
+    async fn send_msg(&self, msg: ChannelMsg) -> Result<(), Error> {
+        self.sender
+            .send((self.id, msg).into())
+            .await
+            .map_err(|_| Error::SendError)
+    }
+}

--- a/russh/src/parsing.rs
+++ b/russh/src/parsing.rs
@@ -1,0 +1,132 @@
+use super::*;
+use russh_cryptovec::CryptoVec;
+use russh_keys::encoding::{Encoding, Position};
+
+#[derive(Debug)]
+pub struct OpenChannelMessage {
+    pub typ: ChannelType,
+    pub recipient_channel: u32,
+    pub recipient_window_size: u32,
+    pub recipient_maximum_packet_size: u32,
+}
+
+impl OpenChannelMessage {
+    pub fn parse(r: &mut Position) -> Result<Self, crate::Error> {
+        // https://tools.ietf.org/html/rfc4254#section-5.1
+        let typ = r.read_string().map_err(crate::Error::from)?;
+        let sender = r.read_u32().map_err(crate::Error::from)?;
+        let window = r.read_u32().map_err(crate::Error::from)?;
+        let maxpacket = r.read_u32().map_err(crate::Error::from)?;
+
+        let typ = match typ {
+            b"session" => ChannelType::Session,
+            b"x11" => {
+                let originator_address =
+                    std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
+                        .map_err(crate::Error::from)?
+                        .to_owned();
+                let originator_port = r.read_u32().map_err(crate::Error::from)?;
+                ChannelType::X11 {
+                    originator_address,
+                    originator_port,
+                }
+            }
+            b"direct-tcpip" => {
+                let host_to_connect =
+                    std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
+                        .map_err(crate::Error::from)?
+                        .to_owned();
+                let port_to_connect = r.read_u32().map_err(crate::Error::from)?;
+                let originator_address =
+                    std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
+                        .map_err(crate::Error::from)?
+                        .to_owned();
+                let originator_port = r.read_u32().map_err(crate::Error::from)?;
+                ChannelType::DirectTcpip {
+                    host_to_connect,
+                    port_to_connect,
+                    originator_address,
+                    originator_port,
+                }
+            }
+            t => ChannelType::Unknown { typ: t.to_vec() },
+        };
+
+        Ok(Self {
+            typ,
+            recipient_channel: sender,
+            recipient_window_size: window,
+            recipient_maximum_packet_size: maxpacket,
+        })
+    }
+
+    /// Pushes a confirmation that this channel was opened to the vec.
+    pub fn confirm(
+        &self,
+        buffer: &mut CryptoVec,
+        sender_channel: u32,
+        window_size: u32,
+        packet_size: u32,
+    ) {
+        push_packet!(buffer, {
+            buffer.push(msg::CHANNEL_OPEN_CONFIRMATION);
+            buffer.push_u32_be(self.recipient_channel); // remote channel number.
+            buffer.push_u32_be(sender_channel); // our channel number.
+            buffer.push_u32_be(window_size);
+            buffer.push_u32_be(packet_size);
+        });
+    }
+
+    /// Pushes an unknown type error to the vec.
+    pub fn unknown_type(&self, buffer: &mut CryptoVec) {
+        push_packet!(buffer, {
+            buffer.push(msg::CHANNEL_OPEN_FAILURE);
+            buffer.push_u32_be(self.recipient_channel);
+            buffer.push_u32_be(3); // SSH_OPEN_UNKNOWN_CHANNEL_TYPE
+            buffer.extend_ssh_string(b"Unknown channel type");
+            buffer.extend_ssh_string(b"en");
+        });
+    }
+}
+
+#[derive(Debug)]
+pub enum ChannelType {
+    Session,
+    X11 {
+        originator_address: String,
+        originator_port: u32,
+    },
+    DirectTcpip {
+        host_to_connect: String,
+        port_to_connect: u32,
+        originator_address: String,
+        originator_port: u32,
+    },
+    Unknown {
+        typ: Vec<u8>,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct ChannelOpenConfirmation {
+    pub recipient_channel: u32,
+    pub sender_channel: u32,
+    pub initial_window_size: u32,
+    pub maximum_packet_size: u32,
+}
+
+impl ChannelOpenConfirmation {
+    pub fn parse(r: &mut Position) -> Result<Self, crate::Error> {
+        let recipient_channel = r.read_u32().map_err(crate::Error::from)?;
+        let sender_channel = r.read_u32().map_err(crate::Error::from)?;
+        let initial_window_size = r.read_u32().map_err(crate::Error::from)?;
+        let maximum_packet_size = r.read_u32().map_err(crate::Error::from)?;
+
+        Ok(Self {
+            recipient_channel,
+            sender_channel,
+            initial_window_size,
+            maximum_packet_size,
+        })
+    }
+}

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -14,14 +14,18 @@
 //
 
 use std;
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use futures::future::Future;
 use russh_keys::key;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::pin;
+use tokio::task::JoinHandle;
 
 use crate::cipher::{clear, CipherPair, OpeningKey};
 use crate::session::*;
@@ -157,6 +161,12 @@ pub trait Handler: Sized {
     /// default handlers.
     fn finished(self, session: Session) -> Self::FutureUnit;
 
+    /// Called when a session disconnects.
+    #[allow(unused_variables)]
+    fn disconnected(self, session: Session) -> Self::FutureUnit {
+        self.finished(session)
+    }
+
     /// Check authentication using the "none" method. Russh makes
     /// sure rejection happens in time `config.auth_rejection_time`,
     /// except if this method takes more than that.
@@ -208,6 +218,12 @@ pub trait Handler: Sized {
         })
     }
 
+    /// Called when authentication succeeds for a session.
+    #[allow(unused_variables)]
+    fn auth_succeeded(self, session: Session) -> Self::FutureUnit {
+        self.finished(session)
+    }
+
     /// Called when the client closes a channel.
     #[allow(unused_variables)]
     fn channel_close(self, channel: ChannelId, session: Session) -> Self::FutureUnit {
@@ -238,7 +254,7 @@ pub trait Handler: Sized {
         self.finished(session)
     }
 
-    /// Called when a new channel is created.
+    /// Called when a new TCP/IP is created.
     #[allow(unused_variables)]
     fn channel_open_direct_tcpip(
         self,
@@ -252,10 +268,41 @@ pub trait Handler: Sized {
         self.finished(session)
     }
 
+    /// Called when the client confirmed our request to open a
+    /// channel. A channel can only be written to after receiving this
+    /// message (this library panics otherwise).
+    #[allow(unused_variables)]
+    fn channel_open_confirmation(
+        self,
+        id: ChannelId,
+        max_packet_size: u32,
+        window_size: u32,
+        session: Session,
+    ) -> Self::FutureUnit {
+        if let Some(channel) = session.channels.get(&id) {
+            channel
+                .send(ChannelMsg::Open {
+                    id,
+                    max_packet_size,
+                    window_size,
+                })
+                .unwrap_or(());
+        } else {
+            error!("no channel for id {:?}", id);
+        }
+        self.finished(session)
+    }
+
     /// Called when a data packet is received. A response can be
     /// written to the `response` argument.
     #[allow(unused_variables)]
     fn data(self, channel: ChannelId, data: &[u8], session: Session) -> Self::FutureUnit {
+        if let Some(chan) = session.channels.get(&channel) {
+            chan.send(ChannelMsg::Data {
+                data: CryptoVec::from_slice(data),
+            })
+            .unwrap_or(())
+        }
         self.finished(session)
     }
 
@@ -271,6 +318,13 @@ pub trait Handler: Sized {
         data: &[u8],
         session: Session,
     ) -> Self::FutureUnit {
+        if let Some(chan) = session.channels.get(&channel) {
+            chan.send(ChannelMsg::ExtendedData {
+                ext: code,
+                data: CryptoVec::from_slice(data),
+            })
+            .unwrap_or(())
+        }
         self.finished(session)
     }
 
@@ -456,17 +510,42 @@ async fn start_reading<R: AsyncRead + Unpin>(
     Ok((n, stream_read, buffer, cipher))
 }
 
-pub async fn run_stream<H: Handler, R>(
+pub struct RunningSession<H: Handler> {
+    handle: Handle,
+    join: JoinHandle<Result<(), H::Error>>,
+}
+
+impl<H: Handler> RunningSession<H> {
+    /// Returns a copy of the handle for the session.
+    pub fn handle(&self) -> Handle {
+        self.handle.clone()
+    }
+}
+
+impl<H: Handler> Future for RunningSession<H> {
+    type Output = Result<(), H::Error>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match Future::poll(Pin::new(&mut self.join), cx) {
+            Poll::Ready(r) => Poll::Ready(match r {
+                Ok(Ok(x)) => Ok(x),
+                Err(e) => Err(crate::Error::from(e).into()),
+                Ok(Err(e)) => Err(e),
+            }),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub async fn run_stream<H, R>(
     config: Arc<Config>,
     mut stream: R,
-    mut handler: H,
-) -> Result<H, H::Error>
+    handler: H,
+) -> Result<RunningSession<H>, H::Error>
 where
-    R: AsyncRead + AsyncWrite + Unpin,
+    H: Handler + Send + 'static,
+    R: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    let delay = config.connection_timeout;
     // Writing SSH id.
-    let mut decomp = CryptoVec::new();
     let mut write_buffer = SSHBuffer::new();
     write_buffer.send_ssh_id(config.as_ref().server_id.as_bytes());
     stream
@@ -475,147 +554,24 @@ where
         .map_err(crate::Error::from)?;
 
     // Reading SSH id and allocating a session.
-    let mut stream = SshRead::new(&mut stream);
+    let mut stream = SshRead::new(stream);
     let common = read_ssh_id(config, &mut stream).await?;
     let (sender, receiver) = tokio::sync::mpsc::channel(10);
-    let mut session = Session {
+    let handle = server::session::Handle { sender };
+    let session = Session {
+        session_id: get_session_id(),
         target_window_size: common.config.window_size,
         common,
         receiver,
-        sender: server::session::Handle { sender },
+        sender: handle.clone(),
         pending_reads: Vec::new(),
         pending_len: 0,
+        channels: HashMap::new(),
     };
-    session.flush()?;
-    stream
-        .write_all(&session.common.write_buffer.buffer)
-        .await
-        .map_err(crate::Error::from)?;
-    session.common.write_buffer.buffer.clear();
 
-    let (stream_read, mut stream_write) = stream.split();
-    let buffer = SSHBuffer::new();
+    let join = tokio::spawn(session.run(stream, handler));
 
-    // Allow handing out references to the cipher
-    let mut opening_cipher = Box::new(clear::Key) as Box<dyn OpeningKey + Send>;
-    std::mem::swap(
-        &mut opening_cipher,
-        &mut session.common.cipher.remote_to_local,
-    );
-
-    let reading = start_reading(stream_read, buffer, opening_cipher);
-    pin!(reading);
-    let mut is_reading = None;
-
-    #[allow(clippy::panic)] // false positive in macro
-    while !session.common.disconnected {
-        tokio::select! {
-            r = &mut reading => {
-                let (stream_read, buffer, mut opening_cipher) = match r {
-                    Ok((_, stream_read, buffer, opening_cipher)) => (stream_read, buffer, opening_cipher),
-                    Err(e) => return Err(e.into())
-                };
-                if buffer.buffer.len() < 5 {
-                    is_reading = Some((stream_read, buffer, opening_cipher));
-                    break
-                }
-                #[allow(clippy::indexing_slicing)] // length checked
-                let buf = if let Some(ref mut enc) = session.common.encrypted {
-                    let d = enc.decompress.decompress(
-                        &buffer.buffer[5..],
-                        &mut decomp,
-                    );
-                    if let Ok(buf) = d {
-                        buf
-                    } else {
-                        debug!("err = {:?}", d);
-                        is_reading = Some((stream_read, buffer, opening_cipher));
-                        break
-                    }
-                } else {
-                    &buffer.buffer[5..]
-                };
-                if !buf.is_empty() {
-                    #[allow(clippy::indexing_slicing)] // length checked
-                    if buf[0] == crate::msg::DISCONNECT {
-                        debug!("break");
-                        is_reading = Some((stream_read, buffer, opening_cipher));
-                        break;
-                    } else if buf[0] > 4 {
-                        std::mem::swap(&mut opening_cipher, &mut session.common.cipher.remote_to_local);
-                        // TODO it'd be cleaner to just pass cipher to reply()
-                        match reply(session, handler, buf).await {
-                            Ok((h, s)) => {
-                                handler = h;
-                                session = s;
-                            },
-                            Err(e) => return Err(e),
-                        }
-                        std::mem::swap(&mut opening_cipher, &mut session.common.cipher.remote_to_local);
-                    }
-                }
-                reading.set(start_reading(stream_read, buffer, opening_cipher));
-            }
-            _ = timeout(delay) => {
-                debug!("timeout");
-                break
-            },
-            msg = session.receiver.recv(), if !session.is_rekeying() => {
-                match msg {
-                    Some((id, ChannelMsg::Data { data })) => {
-                        session.data(id, data);
-                    }
-                    Some((id, ChannelMsg::ExtendedData { ext, data })) => {
-                        session.extended_data(id, ext, data);
-                    }
-                    Some((id, ChannelMsg::Eof)) => {
-                        session.eof(id);
-                    }
-                    Some((id, ChannelMsg::Close)) => {
-                        session.close(id);
-                    }
-                    Some((id, ChannelMsg::Success)) => {
-                        session.channel_success(id);
-                    }
-                    Some((id, ChannelMsg::XonXoff { client_can_do })) => {
-                        session.xon_xoff_request(id, client_can_do);
-                    }
-                    Some((id, ChannelMsg::ExitStatus { exit_status })) => {
-                        session.exit_status_request(id, exit_status);
-                    }
-                    Some((id, ChannelMsg::ExitSignal { signal_name, core_dumped, error_message, lang_tag })) => {
-                        session.exit_signal_request(id, signal_name, core_dumped, &error_message, &lang_tag);
-                    }
-                    Some((id, ChannelMsg::WindowAdjusted { new_size })) => {
-                        debug!("window adjusted to {:?} for channel {:?}", new_size, id);
-                    }
-                    None => {
-                        debug!("session.receiver: received None");
-                    }
-                }
-            }
-        }
-        session.flush()?;
-        stream_write
-            .write_all(&session.common.write_buffer.buffer)
-            .await
-            .map_err(crate::Error::from)?;
-        session.common.write_buffer.buffer.clear();
-    }
-    debug!("disconnected");
-    // Shutdown
-    stream_write.shutdown().await.map_err(crate::Error::from)?;
-    loop {
-        if let Some((stream_read, buffer, opening_cipher)) = is_reading.take() {
-            reading.set(start_reading(stream_read, buffer, opening_cipher));
-        }
-        let (n, r, b, opening_cipher) = (&mut reading).await?;
-        is_reading = Some((r, b, opening_cipher));
-        if n == 0 {
-            break;
-        }
-    }
-    Ok(handler)
+    Ok(RunningSession { handle, join })
 }
 
 async fn read_ssh_id<R: AsyncRead + Unpin>(

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -1,36 +1,77 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use russh_keys::encoding::Encoding;
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+    sync::mpsc::{unbounded_channel, UnboundedSender},
+};
 
 use super::*;
-use crate::msg;
+use crate::{
+    channels::{Channel, ChannelMsg},
+    msg,
+};
+
+static SESSION_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+pub(crate) fn get_session_id() -> usize {
+    SESSION_COUNTER.fetch_add(1, Ordering::SeqCst)
+}
 
 /// A connected server session. This type is unique to a client.
 pub struct Session {
+    pub(crate) session_id: usize,
     pub(crate) common: CommonSession<Arc<Config>>,
     pub(crate) sender: Handle,
-    pub(crate) receiver: Receiver<(ChannelId, ChannelMsg)>,
+    pub(crate) receiver: Receiver<Msg>,
     pub(crate) target_window_size: u32,
     pub(crate) pending_reads: Vec<CryptoVec>,
     pub(crate) pending_len: u32,
+    pub(crate) channels: HashMap<ChannelId, UnboundedSender<ChannelMsg>>,
+}
+#[derive(Debug)]
+pub enum Msg {
+    ChannelOpenSession {
+        sender: UnboundedSender<ChannelMsg>,
+    },
+    ChannelOpenDirectTcpIp {
+        host_to_connect: String,
+        port_to_connect: u32,
+        originator_address: String,
+        originator_port: u32,
+        sender: UnboundedSender<ChannelMsg>,
+    },
+    Channel(ChannelId, ChannelMsg),
+}
+
+impl From<(ChannelId, ChannelMsg)> for Msg {
+    fn from((id, msg): (ChannelId, ChannelMsg)) -> Self {
+        Msg::Channel(id, msg)
+    }
 }
 
 #[derive(Clone)]
 /// Handle to a session, used to send messages to a client outside of
 /// the request/response cycle.
 pub struct Handle {
-    pub(crate) sender: Sender<(ChannelId, ChannelMsg)>,
+    pub(crate) sender: Sender<Msg>,
 }
 
 impl Handle {
     /// Send data to the session referenced by this handler.
     pub async fn data(&mut self, id: ChannelId, data: CryptoVec) -> Result<(), CryptoVec> {
         self.sender
-            .send((id, ChannelMsg::Data { data }))
+            .send(Msg::Channel(id, ChannelMsg::Data { data }))
             .await
             .map_err(|e| match e.0 {
-                (_, ChannelMsg::Data { data }) => data,
+                Msg::Channel(_, ChannelMsg::Data { data }) => data,
                 _ => unreachable!(),
             })
     }
@@ -43,10 +84,10 @@ impl Handle {
         data: CryptoVec,
     ) -> Result<(), CryptoVec> {
         self.sender
-            .send((id, ChannelMsg::ExtendedData { ext, data }))
+            .send(Msg::Channel(id, ChannelMsg::ExtendedData { ext, data }))
             .await
             .map_err(|e| match e.0 {
-                (_, ChannelMsg::ExtendedData { data, .. }) => data,
+                Msg::Channel(_, ChannelMsg::ExtendedData { data, .. }) => data,
                 _ => unreachable!(),
             })
     }
@@ -54,7 +95,7 @@ impl Handle {
     /// Send EOF to the session referenced by this handler.
     pub async fn eof(&mut self, id: ChannelId) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::Eof))
+            .send(Msg::Channel(id, ChannelMsg::Eof))
             .await
             .map_err(|_| ())
     }
@@ -62,7 +103,7 @@ impl Handle {
     /// Send success to the session referenced by this handler.
     pub async fn channel_success(&mut self, id: ChannelId) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::Success))
+            .send(Msg::Channel(id, ChannelMsg::Success))
             .await
             .map_err(|_| ())
     }
@@ -70,7 +111,7 @@ impl Handle {
     /// Close a channel.
     pub async fn close(&mut self, id: ChannelId) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::Close))
+            .send(Msg::Channel(id, ChannelMsg::Close))
             .await
             .map_err(|_| ())
     }
@@ -80,7 +121,7 @@ impl Handle {
     /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-6.8).
     pub async fn xon_xoff_request(&mut self, id: ChannelId, client_can_do: bool) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::XonXoff { client_can_do }))
+            .send(Msg::Channel(id, ChannelMsg::XonXoff { client_can_do }))
             .await
             .map_err(|_| ())
     }
@@ -88,9 +129,78 @@ impl Handle {
     /// Send the exit status of a program.
     pub async fn exit_status_request(&mut self, id: ChannelId, exit_status: u32) -> Result<(), ()> {
         self.sender
-            .send((id, ChannelMsg::ExitStatus { exit_status }))
+            .send(Msg::Channel(id, ChannelMsg::ExitStatus { exit_status }))
             .await
             .map_err(|_| ())
+    }
+
+    /// Request a session channel (the most basic type of
+    /// channel). This function returns `Some(..)` immediately if the
+    /// connection is authenticated, but the channel only becomes
+    /// usable when it's confirmed by the server, as indicated by the
+    /// `confirmed` field of the corresponding `Channel`.
+    pub async fn channel_open_session(&mut self) -> Result<Channel<Msg>, Error> {
+        let (sender, receiver) = unbounded_channel();
+        self.sender
+            .send(Msg::ChannelOpenSession { sender })
+            .await
+            .map_err(|_| Error::SendError)?;
+        self.wait_channel_confirmation(receiver).await
+    }
+
+    /// Open a TCP/IP forwarding channel. This is usually done when a
+    /// connection comes to a locally forwarded TCP/IP port. See
+    /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-7). The
+    /// TCP/IP packets can then be tunneled through the channel using
+    /// `.data()`.
+    pub async fn channel_open_direct_tcpip<A: Into<String>, B: Into<String>>(
+        &mut self,
+        host_to_connect: A,
+        port_to_connect: u32,
+        originator_address: B,
+        originator_port: u32,
+    ) -> Result<Channel<Msg>, Error> {
+        let (sender, receiver) = unbounded_channel();
+        self.sender
+            .send(Msg::ChannelOpenDirectTcpIp {
+                host_to_connect: host_to_connect.into(),
+                port_to_connect,
+                originator_address: originator_address.into(),
+                originator_port,
+                sender,
+            })
+            .await
+            .map_err(|_| Error::SendError)?;
+        self.wait_channel_confirmation(receiver).await
+    }
+
+    async fn wait_channel_confirmation(
+        &self,
+        mut receiver: UnboundedReceiver<ChannelMsg>,
+    ) -> Result<Channel<Msg>, Error> {
+        loop {
+            match receiver.recv().await {
+                Some(ChannelMsg::Open {
+                    id,
+                    max_packet_size,
+                    window_size,
+                }) => {
+                    return Ok(Channel {
+                        id,
+                        sender: self.sender.clone(),
+                        receiver,
+                        max_packet_size,
+                        window_size,
+                    });
+                }
+                None => {
+                    return Err(Error::Disconnect);
+                }
+                msg => {
+                    debug!("msg = {:?}", msg);
+                }
+            }
+        }
     }
 
     /// If the program was killed by a signal, send the details about the signal to the client.
@@ -103,7 +213,7 @@ impl Handle {
         lang_tag: String,
     ) -> Result<(), ()> {
         self.sender
-            .send((
+            .send(Msg::Channel(
                 id,
                 ChannelMsg::ExitSignal {
                     signal_name,
@@ -124,6 +234,166 @@ impl Session {
         } else {
             true
         }
+    }
+
+    pub(crate) async fn run<H, R>(
+        mut self,
+        mut stream: SshRead<R>,
+        mut handler: H,
+    ) -> Result<(), H::Error>
+    where
+        H: Handler + Send + 'static,
+        R: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        self.flush()?;
+        stream
+            .write_all(&self.common.write_buffer.buffer)
+            .await
+            .map_err(crate::Error::from)?;
+        self.common.write_buffer.buffer.clear();
+
+        let (stream_read, mut stream_write) = stream.split();
+        let buffer = SSHBuffer::new();
+
+        // Allow handing out references to the cipher
+        let mut opening_cipher = Box::new(clear::Key) as Box<dyn OpeningKey + Send>;
+        std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
+
+        let reading = start_reading(stream_read, buffer, opening_cipher);
+        pin!(reading);
+        let mut is_reading = None;
+        let mut decomp = CryptoVec::new();
+        let delay = self.common.config.connection_timeout;
+
+        #[allow(clippy::panic)] // false positive in macro
+        while !self.common.disconnected {
+            tokio::select! {
+                r = &mut reading => {
+                    let (stream_read, buffer, mut opening_cipher) = match r {
+                        Ok((_, stream_read, buffer, opening_cipher)) => (stream_read, buffer, opening_cipher),
+                        Err(e) => return Err(e.into())
+                    };
+                    if buffer.buffer.len() < 5 {
+                        is_reading = Some((stream_read, buffer, opening_cipher));
+                        break
+                    }
+                    #[allow(clippy::indexing_slicing)] // length checked
+                    let buf = if let Some(ref mut enc) = self.common.encrypted {
+                        let d = enc.decompress.decompress(
+                            &buffer.buffer[5..],
+                            &mut decomp,
+                        );
+                        if let Ok(buf) = d {
+                            buf
+                        } else {
+                            debug!("err = {:?}", d);
+                            is_reading = Some((stream_read, buffer, opening_cipher));
+                            break
+                        }
+                    } else {
+                        &buffer.buffer[5..]
+                    };
+                    if !buf.is_empty() {
+                        #[allow(clippy::indexing_slicing)] // length checked
+                        if buf[0] == crate::msg::DISCONNECT {
+                            debug!("break");
+                            is_reading = Some((stream_read, buffer, opening_cipher));
+                            break;
+                        } else if buf[0] > 4 {
+                            std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
+                            // TODO it'd be cleaner to just pass cipher to reply()
+                            match reply(self, handler, buf).await {
+                                Ok((h, s)) => {
+                                    handler = h;
+                                    self = s;
+                                },
+                                Err(e) => return Err(e),
+                            }
+                            std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
+                        }
+                    }
+                    reading.set(start_reading(stream_read, buffer, opening_cipher));
+                }
+                _ = timeout(delay) => {
+                    debug!("timeout");
+                    break
+                },
+                msg = self.receiver.recv(), if !self.is_rekeying() => {
+                    match msg {
+                        Some(Msg::Channel(id, ChannelMsg::Data { data })) => {
+                            self.data(id, data);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::ExtendedData { ext, data })) => {
+                            self.extended_data(id, ext, data);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::Eof)) => {
+                            self.eof(id);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::Close)) => {
+                            self.close(id);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::Success)) => {
+                            self.channel_success(id);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::XonXoff { client_can_do })) => {
+                            self.xon_xoff_request(id, client_can_do);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::ExitStatus { exit_status })) => {
+                            self.exit_status_request(id, exit_status);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::ExitSignal { signal_name, core_dumped, error_message, lang_tag })) => {
+                            self.exit_signal_request(id, signal_name, core_dumped, &error_message, &lang_tag);
+                        }
+                        Some(Msg::Channel(id, ChannelMsg::WindowAdjusted { new_size })) => {
+                            debug!("window adjusted to {:?} for channel {:?}", new_size, id);
+                        }
+                        Some(Msg::ChannelOpenSession { sender }) => {
+                            let id = self.channel_open_session()?;
+                            self.channels.insert(id, sender);
+                        }
+                        Some(Msg::ChannelOpenDirectTcpIp { host_to_connect, port_to_connect, originator_address, originator_port, sender }) => {
+                            let id = self.channel_open_direct_tcpip(&host_to_connect, port_to_connect, &originator_address, originator_port)?;
+                            self.channels.insert(id, sender);
+                        }
+                        Some(_) => {
+                            // should be unreachable, since the receiver only gets
+                            // messages from methods implemented within russh
+                            unimplemented!("unimplemented (client-only?) message: {:?}", msg)
+                        }
+                        None => {
+                            debug!("self.receiver: received None");
+                        }
+                    }
+                }
+            }
+            self.flush()?;
+            stream_write
+                .write_all(&self.common.write_buffer.buffer)
+                .await
+                .map_err(crate::Error::from)?;
+            self.common.write_buffer.buffer.clear();
+        }
+        debug!("disconnected");
+        // Shutdown
+        stream_write.shutdown().await.map_err(crate::Error::from)?;
+        loop {
+            if let Some((stream_read, buffer, opening_cipher)) = is_reading.take() {
+                reading.set(start_reading(stream_read, buffer, opening_cipher));
+            }
+            let (n, r, b, opening_cipher) = (&mut reading).await?;
+            is_reading = Some((r, b, opening_cipher));
+            if n == 0 {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Application-unqiue session ID. Can be used for identifying the session
+    /// across method calls.
+    pub fn id(&self) -> usize {
+        self.session_id
     }
 
     /// Get a handle to this session.
@@ -394,6 +664,89 @@ impl Session {
         }
     }
 
+    /// Opens a new session channel on the client.
+    pub fn channel_open_session(&mut self) -> Result<ChannelId, Error> {
+        let result = if let Some(ref mut enc) = self.common.encrypted {
+            if !matches!(
+                enc.state,
+                EncryptedState::Authenticated | EncryptedState::InitCompression
+            ) {
+                return Err(Error::Inconsistent);
+            }
+
+            let sender_channel = enc.new_channel(
+                self.common.config.window_size,
+                self.common.config.maximum_packet_size,
+            );
+            push_packet!(enc.write, {
+                enc.write.push(msg::CHANNEL_OPEN);
+                enc.write.extend_ssh_string(b"session");
+
+                // sender channel id.
+                enc.write.push_u32_be(sender_channel.0);
+
+                // window.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().window_size);
+
+                // max packet size.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().maximum_packet_size);
+            });
+            sender_channel
+        } else {
+            return Err(Error::Inconsistent);
+        };
+        Ok(result)
+    }
+
+    /// Opens a direct TCP/IP channel on the client.
+    pub fn channel_open_direct_tcpip(
+        &mut self,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        originator_address: &str,
+        originator_port: u32,
+    ) -> Result<ChannelId, Error> {
+        let result = if let Some(ref mut enc) = self.common.encrypted {
+            if !matches!(
+                enc.state,
+                EncryptedState::Authenticated | EncryptedState::InitCompression
+            ) {
+                return Err(Error::Inconsistent);
+            }
+            let sender_channel = enc.new_channel(
+                self.common.config.window_size,
+                self.common.config.maximum_packet_size,
+            );
+            push_packet!(enc.write, {
+                enc.write.push(msg::CHANNEL_OPEN);
+                enc.write.extend_ssh_string(b"direct-tcpip");
+
+                // sender channel id.
+                enc.write.push_u32_be(sender_channel.0);
+
+                // window.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().window_size);
+
+                // max packet size.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().maximum_packet_size);
+
+                enc.write.extend_ssh_string(host_to_connect.as_bytes());
+                enc.write.push_u32_be(port_to_connect); // sender channel id.
+                enc.write.extend_ssh_string(originator_address.as_bytes());
+                enc.write.push_u32_be(originator_port); // sender channel id.
+            });
+            sender_channel
+        } else {
+            return Err(Error::Inconsistent);
+        };
+
+        Ok(result)
+    }
+
     /// Open a TCP/IP forwarding channel, when a connection comes to a
     /// local port for which forwarding has been requested. See
     /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-7). The
@@ -407,38 +760,39 @@ impl Session {
         originator_port: u32,
     ) -> Result<ChannelId, Error> {
         let result = if let Some(ref mut enc) = self.common.encrypted {
-            match enc.state {
-                EncryptedState::Authenticated => {
-                    debug!("sending open request");
-
-                    let sender_channel = enc.new_channel(
-                        self.common.config.window_size,
-                        self.common.config.maximum_packet_size,
-                    );
-                    push_packet!(enc.write, {
-                        enc.write.push(msg::CHANNEL_OPEN);
-                        enc.write.extend_ssh_string(b"forwarded-tcpip");
-
-                        // sender channel id.
-                        enc.write.push_u32_be(sender_channel.0);
-
-                        // window.
-                        enc.write
-                            .push_u32_be(self.common.config.as_ref().window_size);
-
-                        // max packet size.
-                        enc.write
-                            .push_u32_be(self.common.config.as_ref().maximum_packet_size);
-
-                        enc.write.extend_ssh_string(connected_address.as_bytes());
-                        enc.write.push_u32_be(connected_port); // sender channel id.
-                        enc.write.extend_ssh_string(originator_address.as_bytes());
-                        enc.write.push_u32_be(originator_port); // sender channel id.
-                    });
-                    sender_channel
-                }
-                _ => return Err(Error::Inconsistent),
+            if !matches!(
+                enc.state,
+                EncryptedState::Authenticated | EncryptedState::InitCompression
+            ) {
+                return Err(Error::Inconsistent);
             }
+
+            debug!("sending open request");
+            let sender_channel = enc.new_channel(
+                self.common.config.window_size,
+                self.common.config.maximum_packet_size,
+            );
+            push_packet!(enc.write, {
+                enc.write.push(msg::CHANNEL_OPEN);
+                enc.write.extend_ssh_string(b"forwarded-tcpip");
+
+                // sender channel id.
+                enc.write.push_u32_be(sender_channel.0);
+
+                // window.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().window_size);
+
+                // max packet size.
+                enc.write
+                    .push_u32_be(self.common.config.as_ref().maximum_packet_size);
+
+                enc.write.extend_ssh_string(connected_address.as_bytes());
+                enc.write.push_u32_be(connected_port); // sender channel id.
+                enc.write.extend_ssh_string(originator_address.as_bytes());
+                enc.write.push_u32_be(originator_port); // sender channel id.
+            });
+            sender_channel
         } else {
             return Err(Error::Inconsistent);
         };


### PR DESCRIPTION
Channels need not be exclusively client-created, in fact few (if any?)
channels specify directionality, and refer only to a sender and receiver.

This does an initial, somewhat minimal pass at making servers capable of
initiating channels. This is rather rough and I think greater
abstraction is warranted here; I pulled out relevant parsing code into
`parsing.rs`, but there is logical duplication between the client and
server which I don't have time to disentagle. This also only implements
_some_ channel functionality on the server-side, it's not as complete as
the client.

The significant breaking change here is that `server::run_stream` now
returns (almost) immediatel with a SessionHandle, similar to the client;
this is used to open channels.

Ultimately this is a big set of changes I would understand if there's
not great desire to merge this upstream :)