### PR TITLE
add support forward-tcpip requests from the server

### DIFF
--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -320,6 +320,7 @@ macro_rules! push_packet {
     }};
 }
 
+mod parsing;
 mod session;
 
 /// Server side of this library.

--- a/russh/src/parsing.rs
+++ b/russh/src/parsing.rs
@@ -1,0 +1,116 @@
+use super::*;
+use russh_cryptovec::CryptoVec;
+use russh_keys::encoding::{Encoding, Position};
+
+#[derive(Debug)]
+pub struct OpenChannelMessage {
+    pub typ: ChannelType,
+    pub recipient_channel: u32,
+    pub recipient_window_size: u32,
+    pub recipient_maximum_packet_size: u32,
+}
+
+impl OpenChannelMessage {
+    pub fn parse(r: &mut Position) -> Result<Self, crate::Error> {
+        // https://tools.ietf.org/html/rfc4254#section-5.1
+        let typ = r.read_string().map_err(crate::Error::from)?;
+        let sender = r.read_u32().map_err(crate::Error::from)?;
+        let window = r.read_u32().map_err(crate::Error::from)?;
+        let maxpacket = r.read_u32().map_err(crate::Error::from)?;
+
+        let typ = match typ {
+            b"session" => ChannelType::Session,
+            b"x11" => {
+                let originator_address =
+                    std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
+                        .map_err(crate::Error::from)?
+                        .to_owned();
+                let originator_port = r.read_u32().map_err(crate::Error::from)?;
+                ChannelType::X11 {
+                    originator_address,
+                    originator_port,
+                }
+            }
+            b"direct-tcpip" => ChannelType::DirectTcpip(TcpChannelInfo::new(r)?),
+            b"forwarded-tcpip" => ChannelType::ForwardedTcpIp(TcpChannelInfo::new(r)?),
+            t => ChannelType::Unknown { typ: t.to_vec() },
+        };
+
+        Ok(Self {
+            typ,
+            recipient_channel: sender,
+            recipient_window_size: window,
+            recipient_maximum_packet_size: maxpacket,
+        })
+    }
+
+    /// Pushes a confirmation that this channel was opened to the vec.
+    pub fn confirm(
+        &self,
+        buffer: &mut CryptoVec,
+        sender_channel: u32,
+        window_size: u32,
+        packet_size: u32,
+    ) {
+        push_packet!(buffer, {
+            buffer.push(msg::CHANNEL_OPEN_CONFIRMATION);
+            buffer.push_u32_be(self.recipient_channel); // remote channel number.
+            buffer.push_u32_be(sender_channel); // our channel number.
+            buffer.push_u32_be(window_size);
+            buffer.push_u32_be(packet_size);
+        });
+    }
+
+    /// Pushes an unknown type error to the vec.
+    pub fn unknown_type(&self, buffer: &mut CryptoVec) {
+        push_packet!(buffer, {
+            buffer.push(msg::CHANNEL_OPEN_FAILURE);
+            buffer.push_u32_be(self.recipient_channel);
+            buffer.push_u32_be(3); // SSH_OPEN_UNKNOWN_CHANNEL_TYPE
+            buffer.extend_ssh_string(b"Unknown channel type");
+            buffer.extend_ssh_string(b"en");
+        });
+    }
+}
+
+#[derive(Debug)]
+pub enum ChannelType {
+    Session,
+    X11 {
+        originator_address: String,
+        originator_port: u32,
+    },
+    DirectTcpip(TcpChannelInfo),
+    ForwardedTcpIp(TcpChannelInfo),
+    Unknown {
+        typ: Vec<u8>,
+    },
+}
+
+#[derive(Debug)]
+pub struct TcpChannelInfo {
+    pub host_to_connect: String,
+    pub port_to_connect: u32,
+    pub originator_address: String,
+    pub originator_port: u32,
+}
+
+impl TcpChannelInfo {
+    fn new(r: &mut Position) -> Result<Self, crate::Error> {
+        let host_to_connect = std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
+            .map_err(crate::Error::from)?
+            .to_owned();
+        let port_to_connect = r.read_u32().map_err(crate::Error::from)?;
+        let originator_address = std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
+            .map_err(crate::Error::from)?
+            .to_owned();
+        let originator_port = r.read_u32().map_err(crate::Error::from)?;
+
+        Ok(Self {
+            host_to_connect,
+            port_to_connect,
+            originator_address,
+            originator_port,
+        })
+    }
+}

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -23,6 +23,8 @@ use russh_keys::key::Verify;
 use tokio::time::Instant;
 use {msg, negotiation};
 
+use crate::parsing::{ChannelType, OpenChannelMessage};
+
 use super::super::*;
 use super::*;
 
@@ -799,17 +801,14 @@ impl Session {
         }
     }
 
+
     async fn server_handle_channel_open<H: Handler>(
         mut self,
         handler: H,
         buf: &[u8],
     ) -> Result<(H, Self), H::Error> {
-        // https://tools.ietf.org/html/rfc4254#section-5.1
         let mut r = buf.reader(1);
-        let typ = r.read_string().map_err(crate::Error::from)?;
-        let sender = r.read_u32().map_err(crate::Error::from)?;
-        let window = r.read_u32().map_err(crate::Error::from)?;
-        let maxpacket = r.read_u32().map_err(crate::Error::from)?;
+        let msg = OpenChannelMessage::parse(&mut r)?;
 
         let sender_channel = if let Some(ref mut enc) = self.common.encrypted {
             enc.new_channel_id()
@@ -817,72 +816,89 @@ impl Session {
             unreachable!()
         };
         let channel = Channel {
-            recipient_channel: sender,
+            recipient_channel: msg.recipient_channel,
 
             // "sender" is the local end, i.e. we're the sender, the remote is the recipient.
             sender_channel,
 
-            recipient_window_size: window,
+            recipient_window_size: msg.recipient_window_size,
             sender_window_size: self.common.config.window_size,
-            recipient_maximum_packet_size: maxpacket,
+            recipient_maximum_packet_size: msg.recipient_maximum_packet_size,
             sender_maximum_packet_size: self.common.config.maximum_packet_size,
             confirmed: true,
             wants_reply: false,
             pending_data: std::collections::VecDeque::new(),
         };
-        match typ {
-            b"session" => {
-                self.confirm_channel_open(channel);
+
+        match &msg.typ {
+            ChannelType::Session => {
+                self.confirm_channel_open(&msg, channel);
                 handler.channel_open_session(sender_channel, self).await
             }
-            b"x11" => {
-                self.confirm_channel_open(channel);
-                let a = std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
-                    .map_err(crate::Error::from)?;
-                let b = r.read_u32().map_err(crate::Error::from)?;
-                handler.channel_open_x11(sender_channel, a, b, self).await
-            }
-            b"direct-tcpip" => {
-                self.confirm_channel_open(channel);
-                let a = std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
-                    .map_err(crate::Error::from)?;
-                let b = r.read_u32().map_err(crate::Error::from)?;
-                let c = std::str::from_utf8(r.read_string().map_err(crate::Error::from)?)
-                    .map_err(crate::Error::from)?;
-                let d = r.read_u32().map_err(crate::Error::from)?;
-                handler
-                    .channel_open_direct_tcpip(sender_channel, a, b, c, d, self)
-                    .await
-            }
-            t => {
-                debug!("unknown channel type: {:?}", t);
-                if let Some(ref mut enc) = self.common.encrypted {
-                    push_packet!(enc.write, {
-                        enc.write.push(msg::CHANNEL_OPEN_FAILURE);
-                        enc.write.push_u32_be(sender);
-                        enc.write.push_u32_be(3); // SSH_OPEN_UNKNOWN_CHANNEL_TYPE
-                        enc.write.extend_ssh_string(b"Unknown channel type");
-                        enc.write.extend_ssh_string(b"en");
-                    });
+            ChannelType::X11 {
+                originator_address,
+                originator_port,
+            } => {
+                let mut result = handler
+                    .channel_open_x11(sender_channel, originator_address, *originator_port, self)
+                    .await;
+                if let Ok((_, s)) = &mut result {
+                    s.confirm_channel_open(&msg, channel);
                 }
+                result
+            }
+            ChannelType::DirectTcpip(d) => {
+                let mut result = handler
+                    .channel_open_direct_tcpip(
+                        sender_channel,
+                        &d.host_to_connect,
+                        d.port_to_connect,
+                        &d.originator_address,
+                        d.originator_port,
+                        self,
+                    )
+                    .await;
+                if let Ok((_, s)) = &mut result {
+                    s.confirm_channel_open(&msg, channel);
+                }
+                result
+            }
+            ChannelType::ForwardedTcpIp(d) => {
+                let mut result = handler
+                    .channel_open_forwarded_tcpip(
+                        sender_channel,
+                        &d.host_to_connect,
+                        d.port_to_connect,
+                        &d.originator_address,
+                        d.originator_port,
+                        self,
+                    )
+                    .await;
+                if let Ok((_, s)) = &mut result {
+                    s.confirm_channel_open(&msg, channel);
+                }
+                result
+            }
+            ChannelType::Unknown { typ } => {
+                debug!("unknown channel type: {}", String::from_utf8_lossy(typ));
+                if let Some(ref mut enc) = self.common.encrypted {
+                    msg.unknown_type(&mut enc.write);
+                }
+
                 Ok((handler, self))
             }
         }
     }
-    fn confirm_channel_open(&mut self, channel: Channel) {
+
+    fn confirm_channel_open(&mut self, open: &OpenChannelMessage, channel: Channel) {
         if let Some(ref mut enc) = self.common.encrypted {
-            server_confirm_channel_open(&mut enc.write, &channel, self.common.config.as_ref());
+            open.confirm(
+                &mut enc.write,
+                channel.sender_channel.0,
+                channel.sender_window_size,
+                channel.sender_maximum_packet_size,
+            );
             enc.channels.insert(channel.sender_channel, channel);
         }
     }
-}
-
-fn server_confirm_channel_open(buffer: &mut CryptoVec, channel: &Channel, config: &Config) {
-    push_packet!(buffer, {
-        buffer.push(msg::CHANNEL_OPEN_CONFIRMATION);
-        buffer.push_u32_be(channel.recipient_channel); // remote channel number.
-        buffer.push_u32_be(channel.sender_channel.0); // our channel number.
-        buffer.push_u32_be(config.window_size);
-        buffer.push_u32_be(config.maximum_packet_size);
-    });
 }

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -252,6 +252,21 @@ pub trait Handler: Sized {
         self.finished(session)
     }
 
+    /// Called when a new forwarded connection comes in.
+    /// https://www.rfc-editor.org/rfc/rfc4254#section-7
+    #[allow(unused_variables)]
+    fn channel_open_forwarded_tcpip(
+        self,
+        channel: ChannelId,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        originator_address: &str,
+        originator_port: u32,
+        session: Session,
+    ) -> Self::FutureUnit {
+        self.finished(session)
+    }
+
     /// Called when a data packet is received. A response can be
     /// written to the `response` argument.
     #[allow(unused_variables)]

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -444,4 +444,32 @@ impl Session {
         };
         Ok(result)
     }
+
+    /// Requests that the client forward connections to the given host and port.
+    /// See [RFC4254](https://tools.ietf.org/html/rfc4254#section-7). The client
+    /// will open forwarded_tcpip channels for each connection.
+    pub fn tcpip_forward(&mut self, address: &str, port: u32) {
+        if let Some(ref mut enc) = self.common.encrypted {
+            push_packet!(enc.write, {
+                enc.write.push(msg::GLOBAL_REQUEST);
+                enc.write.extend_ssh_string(b"tcpip-forward");
+                enc.write.push(0);
+                enc.write.extend_ssh_string(address.as_bytes());
+                enc.write.push_u32_be(port);
+            });
+        }
+    }
+
+    /// Cancels a previously tcpip_forward request.
+    pub fn cancel_tcpip_forward(&mut self, address: &str, port: u32) {
+        if let Some(ref mut enc) = self.common.encrypted {
+            push_packet!(enc.write, {
+                enc.write.push(msg::GLOBAL_REQUEST);
+                enc.write.extend_ssh_string(b"cancel-tcpip-forward");
+                enc.write.push(0);
+                enc.write.extend_ssh_string(address.as_bytes());
+                enc.write.push_u32_be(port);
+            });
+        }
+    }
 }


### PR DESCRIPTION
This is simple enough -- allows the server to ask for forwarded ports,
for which the client can create channels and then forward.