### PR TITLE
Silently handle openssh keepalive requests in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ This is a fork of [Thrussh](//nest.pijul.com/pijul/thrussh) by Pierre-Étienne M
   * `rsa-sha2-256`
   * `rsa-sha2-512`
   * `ssh-rsa` :sparkles:
-* Dependency updates 
+* Dependency updates
+* Handle openssh sshd keepalive channel requests :sparkles:
 
 ## Safety
 

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -440,6 +440,21 @@ impl super::Session {
                             )
                             .await
                     }
+                    b"keepalive@openssh.com" => {
+                        let wants_reply = r.read_byte().map_err(crate::Error::from)?; // should be 1
+                        if wants_reply == 1 {
+                            if let Some(ref mut enc) = self.common.encrypted {
+                                self.common.wants_reply = false;
+                                push_packet!(enc.write, {
+                                    enc.write.push(msg::CHANNEL_SUCCESS);
+                                    enc.write.push_u32_be(channel_num.0)
+                                })
+                            }
+                        } else {
+                            warn!("Received keepalive@openssh.com without reply request!");
+                        }
+                        Ok((client, self))
+                    }
                     _ => {
                         let wants_reply = r.read_byte().map_err(crate::Error::from)?;
                         if wants_reply == 1 {


### PR DESCRIPTION
Using russh to connect to an openssh sshd server with a mostly idle connection, the log is filled with `info`-level events about `keepalive@openssh.com` channel request not being handled.
This works, since OpenSSH interprets the channel_failure just fine as a keepalive response, but fills the log with unnecessary noise.

Handling this non-standard, but widely used extension prevents that.