### PR TITLE
Some code clean up, made some code DRY

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo clippy --verbose --all-features
+      run: cargo clippy --all-features -- -D warnings
 
   Test:
     runs-on: ubuntu-latest

--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -62,7 +62,7 @@ impl Config {
         self.update_proxy_command();
         if let Some(ref proxy_command) = self.proxy_command {
             let cmd: Vec<&str> = proxy_command.split(' ').collect();
-            Stream::proxy_command(cmd.get(0).unwrap_or(&""), cmd.get(1..).unwrap_or(&[]))
+            Stream::proxy_command(cmd.first().unwrap_or(&""), cmd.get(1..).unwrap_or(&[]))
                 .await
                 .map_err(Into::into)
         } else {

--- a/russh-keys/src/agent/client.rs
+++ b/russh-keys/src/agent/client.rs
@@ -304,7 +304,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
                     return (self, Err(e));
                 }
                 (self, Ok(data))
-            } else if self.buf.get(0) == Some(&msg::FAILURE) {
+            } else if self.buf.first() == Some(&msg::FAILURE) {
                 (self, Err(Error::AgentFailure))
             } else {
                 debug!("self.buf = {:?}", &self.buf[..]);

--- a/russh-keys/src/format/pkcs8.rs
+++ b/russh-keys/src/format/pkcs8.rs
@@ -319,7 +319,7 @@ fn clone(src: &[u8], dest: &mut [u8]) {
     let i = src.iter().take_while(|b| **b == 0).count();
     let src = &src[i..];
     let l = dest.len();
-    (&mut dest[l - src.len()..]).clone_from_slice(src)
+    dest[l - src.len()..].clone_from_slice(src)
 }
 
 fn asn1_write_pbes2(writer: yasna::DERWriter, rounds: u64, salt: &[u8], iv: &[u8]) {

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -429,7 +429,10 @@ fn rsa_signature(
 }
 
 /// Parse a public key from a byte slice.
-pub fn parse_public_key(p: &[u8], prefer_hash: Option<SignatureHash>) -> Result<PublicKey, Error> {
+pub fn parse_public_key(
+    p: &[u8],
+    #[cfg(feature = "openssl")] prefer_hash: Option<SignatureHash>,
+) -> Result<PublicKey, Error> {
     let mut pos = p.reader(0);
     let t = pos.read_string()?;
     if t == b"ssh-ed25519" {

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -348,7 +348,7 @@ pub fn check_known_hosts_path<P: AsRef<Path>>(
     let mut line = 1;
     while f.read_line(&mut buffer)? > 0 {
         {
-            if buffer.as_bytes().get(0) == Some(&b'#') {
+            if buffer.as_bytes().first() == Some(&b'#') {
                 buffer.clear();
                 continue;
             }

--- a/russh/examples/remote_shell_call.rs
+++ b/russh/examples/remote_shell_call.rs
@@ -72,7 +72,7 @@ impl Session {
         while let Some(msg) = channel.wait().await {
             match msg {
                 russh::ChannelMsg::Data { ref data } => {
-                    output.write_all(&data).unwrap();
+                    output.write_all(data).unwrap();
                 }
                 russh::ChannelMsg::ExitStatus { exit_status } => {
                     code = Some(exit_status);

--- a/russh/src/channels.rs
+++ b/russh/src/channels.rs
@@ -241,17 +241,14 @@ impl<Send: From<(ChannelId, ChannelMsg)>> Channel<Send> {
     }
 
     /// Send data to a channel.
-    pub async fn data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
-        &mut self,
-        data: R,
-    ) -> Result<(), Error> {
+    pub async fn data<R: tokio::io::AsyncReadExt + Unpin>(&mut self, data: R) -> Result<(), Error> {
         self.send_data(None, data).await
     }
 
     /// Send data to a channel. The number of bytes added to the
     /// "sending pipeline" (to be processed by the event loop) is
     /// returned.
-    pub async fn extended_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+    pub async fn extended_data<R: tokio::io::AsyncReadExt + Unpin>(
         &mut self,
         ext: u32,
         data: R,
@@ -259,7 +256,7 @@ impl<Send: From<(ChannelId, ChannelMsg)>> Channel<Send> {
         self.send_data(Some(ext), data).await
     }
 
-    async fn send_data<R: tokio::io::AsyncReadExt + std::marker::Unpin>(
+    async fn send_data<R: tokio::io::AsyncReadExt + Unpin>(
         &mut self,
         ext: Option<u32>,
         mut data: R,

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -194,7 +194,7 @@ pub async fn read<'a, R: AsyncRead + Unpin>(
     let (ciphertext, tag) = buffer.buffer.split_at_mut(ciphertext_len);
     let plaintext = cipher.open(seqn, ciphertext, tag)?;
 
-    let padding_length = *plaintext.get(0).to_owned().unwrap_or(&0) as usize;
+    let padding_length = *plaintext.first().to_owned().unwrap_or(&0) as usize;
     debug!("reading, padding_length {:?}", padding_length);
     let plaintext_end = plaintext
         .len()

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -23,7 +23,6 @@ use crate::mac::MacAlgorithm;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 use crate::sshbuffer::SSHBuffer;
 use crate::Error;
 
@@ -100,7 +99,7 @@ pub struct CipherPair {
     pub remote_to_local: Box<dyn OpeningKey + Send>,
 }
 
-impl std::fmt::Debug for CipherPair {
+impl Debug for CipherPair {
     fn fmt(&self, _: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         Ok(())
     }
@@ -184,6 +183,7 @@ pub async fn read<'a, R: AsyncRead + Unpin>(
             debug!("reading, clear len = {:?}", buffer.len);
         }
     }
+
     buffer.buffer.resize(buffer.len + 4);
     debug!("read_exact {:?}", buffer.len + 4);
     #[allow(clippy::indexing_slicing)] // length checked

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -441,21 +441,6 @@ impl Session {
                             )
                             .await
                     }
-                    b"keepalive@openssh.com" => {
-                        let wants_reply = r.read_byte().map_err(crate::Error::from)?; // should be 1
-                        if wants_reply == 1 {
-                            if let Some(ref mut enc) = self.common.encrypted {
-                                self.common.wants_reply = false;
-                                push_packet!(enc.write, {
-                                    enc.write.push(msg::CHANNEL_SUCCESS);
-                                    enc.write.push_u32_be(channel_num.0)
-                                })
-                            }
-                        } else {
-                            warn!("Received keepalive@openssh.com without reply request!");
-                        }
-                        Ok((client, self))
-                    }
                     _ => {
                         let wants_reply = r.read_byte().map_err(crate::Error::from)?;
                         if wants_reply == 1 {
@@ -499,14 +484,18 @@ impl Session {
                 let wants_reply = r.read_byte().map_err(crate::Error::from)?;
                 if let Some(ref mut enc) = self.common.encrypted {
                     if req.starts_with(b"keepalive") {
-                        info!(
-                            "Received keep alive message: {:?}",
-                            std::str::from_utf8(req),
-                        );
-                        self.common.wants_reply = false;
-                        push_packet!(enc.write, enc.write.push(msg::REQUEST_SUCCESS))
+                        if wants_reply == 1 {
+                            info!(
+                                "Received keep alive message: {:?}",
+                                std::str::from_utf8(req),
+                            );
+                            self.common.wants_reply = false;
+                            push_packet!(enc.write, enc.write.push(msg::REQUEST_SUCCESS));
+                        } else {
+                            warn!("Received keepalive@openssh.com without reply request!");
+                        }
                     } else {
-                        info!(
+                        warn!(
                             "Unhandled global request: {:?} {:?}",
                             std::str::from_utf8(req),
                             wants_reply

--- a/russh/src/client/kex.rs
+++ b/russh/src/client/kex.rs
@@ -14,7 +14,7 @@ impl KexInit {
         buf: &[u8],
         write_buffer: &mut SSHBuffer,
     ) -> Result<KexDhDone, crate::Error> {
-        debug!("client parse {:?} {:?}", buf.len(), buf);
+        trace!("client parse {:?} {:?}", buf.len(), buf);
         let algo = {
             // read algorithms from packet.
             debug!("extending {:?}", &self.exchange.server_kex_init[..]);

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -515,6 +515,7 @@ impl Session {
                     if buffer.buffer.len() < 5 {
                         break
                     }
+
                     let buf = if let Some(ref mut enc) = self.common.encrypted {
                         #[allow(clippy::indexing_slicing)] // length checked
                         if let Ok(buf) = enc.decompress.decompress(

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -797,7 +797,7 @@ async fn reply<H: Handler>(
     match session.common.kex.take() {
         Some(Kex::Init(kexinit)) => {
             if kexinit.algo.is_some()
-                || buf.get(0) == Some(&msg::KEXINIT)
+                || buf.first() == Some(&msg::KEXINIT)
                 || session.common.encrypted.is_none()
             {
                 let done = kexinit.client_parse(
@@ -828,7 +828,7 @@ async fn reply<H: Handler>(
                 kexdhdone.names.ignore_guessed = false;
                 session.common.kex = Some(Kex::DhDone(kexdhdone));
                 Ok((handler, session))
-            } else if buf.get(0) == Some(&msg::KEX_ECDH_REPLY) {
+            } else if buf.first() == Some(&msg::KEX_ECDH_REPLY) {
                 // We've sent ECDH_INIT, waiting for ECDH_REPLY
                 let (kex, h) = kexdhdone.server_key_check(false, handler, buf).await?;
                 handler = h;
@@ -847,7 +847,7 @@ async fn reply<H: Handler>(
         }
         Some(Kex::Keys(newkeys)) => {
             debug!("newkeys received");
-            if buf.get(0) != Some(&msg::NEWKEYS) {
+            if buf.first() != Some(&msg::NEWKEYS) {
                 return Err(crate::Error::Kex.into());
             }
             if let Some(sender) = sender.take() {

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -1,7 +1,12 @@
-use super::*;
+use russh_cryptovec::CryptoVec;
+use russh_keys::encoding::Encoding;
+
+use crate::client::Session;
+use crate::session::EncryptedState;
+use crate::{msg, ChannelId, Disconnect, Pty, Sig};
 
 impl Session {
-    pub fn channel_open_session(&mut self) -> Result<ChannelId, Error> {
+    pub fn channel_open_session(&mut self) -> Result<ChannelId, crate::Error> {
         let result = if let Some(ref mut enc) = self.common.encrypted {
             match enc.state {
                 EncryptedState::Authenticated => {
@@ -26,10 +31,10 @@ impl Session {
                     });
                     sender_channel
                 }
-                _ => return Err(Error::NotAuthenticated),
+                _ => return Err(crate::Error::NotAuthenticated),
             }
         } else {
-            return Err(Error::Inconsistent);
+            return Err(crate::Error::Inconsistent);
         };
         Ok(result)
     }
@@ -38,7 +43,7 @@ impl Session {
         &mut self,
         originator_address: &str,
         originator_port: u32,
-    ) -> Result<ChannelId, Error> {
+    ) -> Result<ChannelId, crate::Error> {
         let result = if let Some(ref mut enc) = self.common.encrypted {
             match enc.state {
                 EncryptedState::Authenticated => {
@@ -66,10 +71,10 @@ impl Session {
                     });
                     sender_channel
                 }
-                _ => return Err(Error::NotAuthenticated),
+                _ => return Err(crate::Error::NotAuthenticated),
             }
         } else {
-            return Err(Error::Inconsistent);
+            return Err(crate::Error::Inconsistent);
         };
         Ok(result)
     }
@@ -80,7 +85,7 @@ impl Session {
         port_to_connect: u32,
         originator_address: &str,
         originator_port: u32,
-    ) -> Result<ChannelId, Error> {
+    ) -> Result<ChannelId, crate::Error> {
         let result = if let Some(ref mut enc) = self.common.encrypted {
             match enc.state {
                 EncryptedState::Authenticated => {
@@ -110,10 +115,10 @@ impl Session {
                     });
                     sender_channel
                 }
-                _ => return Err(Error::NotAuthenticated),
+                _ => return Err(crate::Error::NotAuthenticated),
             }
         } else {
-            return Err(Error::Inconsistent);
+            return Err(crate::Error::Inconsistent);
         };
         Ok(result)
     }

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -248,7 +248,6 @@ impl Session {
             if let Some(channel) = enc.channels.get(&channel) {
                 push_packet!(enc.write, {
                     enc.write.push(msg::CHANNEL_REQUEST);
-
                     enc.write.push_u32_be(channel.recipient_channel);
                     enc.write.extend_ssh_string(b"signal");
                     enc.write.push(0);

--- a/russh/src/kex/curve25519.rs
+++ b/russh/src/kex/curve25519.rs
@@ -48,7 +48,7 @@ impl KexAlgorithm for Curve25519Kex {
 
         let mut client_pubkey = GroupElement([0; 32]);
         {
-            if payload.get(0) != Some(&msg::KEX_ECDH_INIT) {
+            if payload.first() != Some(&msg::KEX_ECDH_INIT) {
                 return Err(crate::Error::Inconsistent);
             }
 

--- a/russh/src/kex/dh/groups.rs
+++ b/russh/src/kex/dh/groups.rs
@@ -47,7 +47,7 @@ pub const DH_GROUP14: DhGroup = DhGroup {
     exp_size: 256,
 };
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DH {
     prime_num: BigUint,
     generator: usize,

--- a/russh/src/kex/dh/mod.rs
+++ b/russh/src/kex/dh/mod.rs
@@ -67,7 +67,7 @@ impl<D: Digest> std::fmt::Debug for DhGroupKex<D> {
 fn biguint_to_mpint(biguint: &BigUint) -> Vec<u8> {
     let mut mpint = Vec::new();
     let bytes = biguint.to_bytes_be();
-    if let Some(b) = bytes.get(0) {
+    if let Some(b) = bytes.first() {
         if b > &0x7f {
             mpint.push(0);
         }
@@ -86,7 +86,7 @@ impl<D: Digest> KexAlgorithm for DhGroupKex<D> {
         debug!("server_dh");
 
         let client_pubkey = {
-            if payload.get(0) != Some(&msg::KEX_ECDH_INIT) {
+            if payload.first() != Some(&msg::KEX_ECDH_INIT) {
                 return Err(crate::Error::Inconsistent);
             }
 

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -610,7 +610,7 @@ impl Sig {
 }
 
 /// Reason for not being able to open a channel.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum ChannelOpenFailure {
     AdministrativelyProhibited = 1,

--- a/russh/src/mac/crypto.rs
+++ b/russh/src/mac/crypto.rs
@@ -55,6 +55,6 @@ impl<M: digest::Mac + KeyInit + Send + 'static, KL: ArrayLength<u8> + 'static> M
     fn verify(&self, sequence_number: u32, payload: &[u8], mac: &[u8]) -> bool {
         let mut buf = GenericArray::<u8, M::OutputSize>::default();
         self.compute(sequence_number, payload, &mut buf);
-        (&buf).ct_eq(mac).into()
+        buf.ct_eq(mac).into()
     }
 }

--- a/russh/src/msg.rs
+++ b/russh/src/msg.rs
@@ -59,6 +59,8 @@ pub const CHANNEL_SUCCESS: u8 = 99;
 pub const CHANNEL_FAILURE: u8 = 100;
 
 pub const SSH_OPEN_ADMINISTRATIVELY_PROHIBITED: u8 = 1;
+#[allow(dead_code)]
 pub const SSH_OPEN_CONNECT_FAILED: u8 = 2;
 pub const SSH_OPEN_UNKNOWN_CHANNEL_TYPE: u8 = 3;
+#[allow(dead_code)]
 pub const SSH_OPEN_RESOURCE_SHORTAGE: u8 = 4;

--- a/russh/src/parsing.rs
+++ b/russh/src/parsing.rs
@@ -1,9 +1,7 @@
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::{Encoding, Position};
 
-use crate::msg::SSH_OPEN_UNKNOWN_CHANNEL_TYPE;
-
-use super::*;
+use crate::msg;
 
 #[derive(Debug)]
 pub struct OpenChannelMessage {
@@ -77,7 +75,11 @@ impl OpenChannelMessage {
 
     /// Pushes an unknown type error to the vec.
     pub fn unknown_type(&self, buffer: &mut CryptoVec) {
-        self.fail(buffer, SSH_OPEN_UNKNOWN_CHANNEL_TYPE, b"Unknown channel type");
+        self.fail(
+            buffer,
+            msg::SSH_OPEN_UNKNOWN_CHANNEL_TYPE,
+            b"Unknown channel type",
+        );
     }
 }
 

--- a/russh/src/pty.rs
+++ b/russh/src/pty.rs
@@ -1,5 +1,5 @@
 #[allow(non_camel_case_types, missing_docs)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// Standard pseudo-terminal codes.
 pub enum Pty {
     TTY_OP_END = 0,

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -30,7 +30,7 @@ use crate::parsing::{ChannelOpenConfirmation, ChannelType, OpenChannelMessage};
 
 impl Session {
     /// Returns false iff a request was rejected.
-    pub(in crate) async fn server_read_encrypted<H: Handler>(
+    pub(crate) async fn server_read_encrypted<H: Handler>(
         mut self,
         mut handler: H,
         buf: &[u8],

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -46,7 +46,7 @@ impl Session {
 
         #[allow(clippy::unwrap_used)]
         let mut enc = self.common.encrypted.as_mut().unwrap();
-        if buf.get(0) == Some(&msg::KEXINIT) {
+        if buf.first() == Some(&msg::KEXINIT) {
             debug!("Received rekeying request");
             // If we're not currently rekeying, but `buf` is a rekey request
             if let Some(Kex::Init(kexinit)) = enc.rekey.take() {
@@ -85,7 +85,7 @@ impl Session {
                 return Ok((handler, self));
             }
             Some(Kex::Keys(newkeys)) => {
-                if buf.get(0) != Some(&msg::NEWKEYS) {
+                if buf.first() != Some(&msg::NEWKEYS) {
                     return Err(Error::Kex.into());
                 }
                 self.common.write_buffer.bytes = 0;
@@ -134,7 +134,7 @@ impl Session {
         match enc.state {
             EncryptedState::WaitingAuthServiceRequest {
                 ref mut accepted, ..
-            } if buf.get(0) == Some(&msg::SERVICE_REQUEST) => {
+            } if buf.first() == Some(&msg::SERVICE_REQUEST) => {
                 let mut r = buf.reader(1);
                 let request = r.read_string().map_err(crate::Error::from)?;
                 debug!("request: {:?}", std::str::from_utf8(request));
@@ -149,7 +149,7 @@ impl Session {
                 }
                 Ok((handler, self))
             }
-            EncryptedState::WaitingAuthRequest(_) if buf.get(0) == Some(&msg::USERAUTH_REQUEST) => {
+            EncryptedState::WaitingAuthRequest(_) if buf.first() == Some(&msg::USERAUTH_REQUEST) => {
                 handler = enc
                     .server_read_auth_request(instant, handler, buf, &mut self.common.auth_user)
                     .await?;
@@ -161,7 +161,7 @@ impl Session {
                 }
             }
             EncryptedState::WaitingAuthRequest(ref mut auth)
-                if buf.get(0) == Some(&msg::USERAUTH_INFO_RESPONSE) =>
+                if buf.first() == Some(&msg::USERAUTH_INFO_RESPONSE) =>
             {
                 let (h, resp) = read_userauth_info_response(
                     instant,
@@ -562,7 +562,7 @@ impl Session {
                 &buf[..std::cmp::min(buf.len(), 100)]
             );
         }
-        match buf.get(0) {
+        match buf.first() {
             Some(&msg::CHANNEL_OPEN) => self
                 .server_handle_channel_open(handler, buf)
                 .await
@@ -586,7 +586,7 @@ impl Session {
                 let mut r = buf.reader(1);
                 let channel_num = ChannelId(r.read_u32().map_err(crate::Error::from)?);
 
-                let ext = if buf.get(0) == Some(&msg::CHANNEL_DATA) {
+                let ext = if buf.first() == Some(&msg::CHANNEL_DATA) {
                     None
                 } else {
                     Some(r.read_u32().map_err(crate::Error::from)?)

--- a/russh/src/server/kex.rs
+++ b/russh/src/server/kex.rs
@@ -21,7 +21,7 @@ impl KexInit {
         buf: &[u8],
         write_buffer: &mut SSHBuffer,
     ) -> Result<Kex, Error> {
-        if buf.get(0) == Some(&msg::KEXINIT) {
+        if buf.first() == Some(&msg::KEXINIT) {
             let algo = {
                 // read algorithms from packet.
                 self.exchange.client_kex_init.extend(buf);
@@ -81,7 +81,7 @@ impl KexDh {
             Ok(Kex::Dh(self))
         } else {
             // Else, process it.
-            assert!(buf.get(0) == Some(&msg::KEX_ECDH_INIT));
+            assert!(buf.first() == Some(&msg::KEX_ECDH_INIT));
             let mut r = buf.reader(1);
             self.exchange.client_ephemeral.extend(r.read_string()?);
 

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -646,7 +646,7 @@ async fn reply<H: Handler>(
     if session.common.encrypted.is_none() {
         match session.common.kex.take() {
             Some(Kex::Init(kexinit)) => {
-                if kexinit.algo.is_some() || buf.get(0) == Some(&msg::KEXINIT) {
+                if kexinit.algo.is_some() || buf.first() == Some(&msg::KEXINIT) {
                     session.common.kex = Some(kexinit.server_parse(
                         session.common.config.as_ref(),
                         &mut *session.common.cipher.local_to_remote,
@@ -671,7 +671,7 @@ async fn reply<H: Handler>(
                 return Ok((handler, session));
             }
             Some(Kex::Keys(newkeys)) => {
-                if buf.get(0) != Some(&msg::NEWKEYS) {
+                if buf.first() != Some(&msg::NEWKEYS) {
                     return Err(Error::Kex.into());
                 }
                 // Ok, NEWKEYS received, now encrypted.

--- a/russh/src/ssh_read.rs
+++ b/russh/src/ssh_read.rs
@@ -65,8 +65,7 @@ impl<R: AsyncRead + Unpin> AsyncRead for SshRead<R> {
             if id.total > id.bytes_read {
                 let total = id.total.min(id.bytes_read + buf.remaining());
                 #[allow(clippy::indexing_slicing)] // length checked
-                let result = { buf.put_slice(&id.buf[id.bytes_read..total]) };
-                debug!("read {:?} bytes from id.buf", result);
+                buf.put_slice(&id.buf[id.bytes_read..total]);
                 id.bytes_read += total - id.bytes_read;
                 self.id = Some(id);
                 return Poll::Ready(Ok(()));


### PR DESCRIPTION
In this PR I got rid of some "*" imports, and made some code DRY. I have been working a lot with the client code, and I have a future PR coming that should handle some failures that I see when opening a `direct-tcpip` channel

In addition I saw that keep alive request handling was added in #26, however, these requests happen via a Global Request message rather than Channel Request message, so I fixed that behavior.

Let me know if this is acceptable