### PR TITLE
remove unnecessary mut markers on the server Handle

### DIFF
--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -64,7 +64,7 @@ pub struct Handle {
 
 impl Handle {
     /// Send data to the session referenced by this handler.
-    pub async fn data(&mut self, id: ChannelId, data: CryptoVec) -> Result<(), CryptoVec> {
+    pub async fn data(&self, id: ChannelId, data: CryptoVec) -> Result<(), CryptoVec> {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::Data { data }))
             .await
@@ -76,7 +76,7 @@ impl Handle {
 
     /// Send data to the session referenced by this handler.
     pub async fn extended_data(
-        &mut self,
+        &self,
         id: ChannelId,
         ext: u32,
         data: CryptoVec,
@@ -91,7 +91,7 @@ impl Handle {
     }
 
     /// Send EOF to the session referenced by this handler.
-    pub async fn eof(&mut self, id: ChannelId) -> Result<(), ()> {
+    pub async fn eof(&self, id: ChannelId) -> Result<(), ()> {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::Eof))
             .await
@@ -99,7 +99,7 @@ impl Handle {
     }
 
     /// Send success to the session referenced by this handler.
-    pub async fn channel_success(&mut self, id: ChannelId) -> Result<(), ()> {
+    pub async fn channel_success(&self, id: ChannelId) -> Result<(), ()> {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::Success))
             .await
@@ -107,7 +107,7 @@ impl Handle {
     }
 
     /// Send failure to the session referenced by this handler.
-    pub async fn channel_failure(&mut self, id: ChannelId) -> Result<(), ()> {
+    pub async fn channel_failure(&self, id: ChannelId) -> Result<(), ()> {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::Failure))
             .await
@@ -115,7 +115,7 @@ impl Handle {
     }
 
     /// Close a channel.
-    pub async fn close(&mut self, id: ChannelId) -> Result<(), ()> {
+    pub async fn close(&self, id: ChannelId) -> Result<(), ()> {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::Close))
             .await
@@ -125,7 +125,7 @@ impl Handle {
     /// Inform the client of whether they may perform
     /// control-S/control-Q flow control. See
     /// [RFC4254](https://tools.ietf.org/html/rfc4254#section-6.8).
-    pub async fn xon_xoff_request(&mut self, id: ChannelId, client_can_do: bool) -> Result<(), ()> {
+    pub async fn xon_xoff_request(&self, id: ChannelId, client_can_do: bool) -> Result<(), ()> {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::XonXoff { client_can_do }))
             .await
@@ -133,7 +133,7 @@ impl Handle {
     }
 
     /// Send the exit status of a program.
-    pub async fn exit_status_request(&mut self, id: ChannelId, exit_status: u32) -> Result<(), ()> {
+    pub async fn exit_status_request(&self, id: ChannelId, exit_status: u32) -> Result<(), ()> {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::ExitStatus { exit_status }))
             .await
@@ -145,7 +145,7 @@ impl Handle {
     /// connection is authenticated, but the channel only becomes
     /// usable when it's confirmed by the server, as indicated by the
     /// `confirmed` field of the corresponding `Channel`.
-    pub async fn channel_open_session(&mut self) -> Result<Channel<Msg>, Error> {
+    pub async fn channel_open_session(&self) -> Result<Channel<Msg>, Error> {
         let (sender, receiver) = unbounded_channel();
         self.sender
             .send(Msg::ChannelOpenSession { sender })
@@ -160,7 +160,7 @@ impl Handle {
     /// TCP/IP packets can then be tunneled through the channel using
     /// `.data()`.
     pub async fn channel_open_direct_tcpip<A: Into<String>, B: Into<String>>(
-        &mut self,
+        &self,
         host_to_connect: A,
         port_to_connect: u32,
         originator_address: B,
@@ -181,7 +181,7 @@ impl Handle {
     }
 
     pub async fn channel_open_forwarded_tcpip<A: Into<String>, B: Into<String>>(
-        &mut self,
+        &self,
         connected_address: A,
         connected_port: u32,
         originator_address: B,
@@ -231,7 +231,7 @@ impl Handle {
 
     /// If the program was killed by a signal, send the details about the signal to the client.
     pub async fn exit_signal_request(
-        &mut self,
+        &self,
         id: ChannelId,
         signal_name: Sig,
         core_dumped: bool,


### PR DESCRIPTION
The handle is Sync, so removing mutability allows it to be used in an Arc. A little more efficient than cloning the handle around.