### PR TITLE
don't try to rekey if kex is skipped

### DIFF
--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -344,6 +344,11 @@ impl Encrypted {
             self.write_cursor = 0;
             self.write.clear();
         }
+
+        if self.kex.skip_exchange() {
+            return Ok(false);
+        }
+
         let now = std::time::Instant::now();
         let dur = now.duration_since(self.last_rekey);
         Ok(write_buffer.bytes >= limits.rekey_write_limit || dur >= limits.rekey_time_limit)


### PR DESCRIPTION
If key exchange is `none`/skipped, then trying to rekey is invalid.