### PR TITLE
implement clone for keypair()

### DIFF
--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -270,6 +270,7 @@ pub enum KeyPair {
 impl Clone for KeyPair {
     fn clone(&self) -> Self {
         match self {
+            #[allow(clippy::expect_used)]
             Self::Ed25519(kp) => Self::Ed25519(
                 ed25519_dalek::Keypair::from_bytes(&kp.to_bytes())
                     .expect("expected to clone keypair"),
@@ -277,7 +278,7 @@ impl Clone for KeyPair {
             #[cfg(feature = "openssl")]
             Self::RSA { key, hash } => Self::RSA {
                 key: key.clone(),
-                hash: hash.clone(),
+                hash: *hash,
             },
         }
     }

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -267,6 +267,22 @@ pub enum KeyPair {
     },
 }
 
+impl Clone for KeyPair {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Ed25519(kp) => Self::Ed25519(
+                ed25519_dalek::Keypair::from_bytes(&kp.to_bytes())
+                    .expect("expected to clone keypair"),
+            ),
+            #[cfg(feature = "openssl")]
+            Self::RSA { key, hash } => Self::RSA {
+                key: key.clone(),
+                hash: hash.clone(),
+            },
+        }
+    }
+}
+
 impl std::fmt::Debug for KeyPair {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {


### PR DESCRIPTION
In my case, I want to make multiple servers with the same keypair, so this allows it to be cloned.