### PR TITLE
decrease log level verbosity for ordinary messages

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -36,7 +36,7 @@ impl Session {
     ) -> Result<(H, Self), H::Error> {
         #[allow(clippy::indexing_slicing)] // length checked
         {
-            debug!(
+            trace!(
                 "client_read_encrypted, buf = {:?}",
                 &buf[..buf.len().min(20)]
             );
@@ -139,7 +139,7 @@ impl Session {
         buf: &[u8],
     ) -> Result<(H, Self), H::Error> {
         // If we've successfully read a packet.
-        debug!("process_packet buf = {:?} bytes", buf.len());
+        trace!("process_packet buf = {:?} bytes", buf.len());
         trace!("buf = {:?}", buf);
         let mut is_authenticated = false;
         if let Some(ref mut enc) = self.common.encrypted {
@@ -352,7 +352,7 @@ impl Session {
                     .await
             }
             Some(&msg::CHANNEL_DATA) => {
-                debug!("channel_data");
+                trace!("channel_data");
                 let mut r = buf.reader(1);
                 let channel_num = ChannelId(r.read_u32().map_err(crate::Error::from)?);
                 let data = r.read_string().map_err(crate::Error::from)?;

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -627,7 +627,7 @@ impl Session {
             }
             self.flush()?;
             if !self.common.write_buffer.buffer.is_empty() {
-                debug!(
+                trace!(
                     "writing to stream: {:?} bytes",
                     self.common.write_buffer.buffer.len()
                 );

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -37,7 +37,7 @@ impl Session {
     ) -> Result<(H, Self), H::Error> {
         #[allow(clippy::indexing_slicing)] // length checked
         {
-            debug!(
+            trace!(
                 "server_read_encrypted, buf = {:?}",
                 &buf[..buf.len().min(20)]
             );
@@ -115,7 +115,7 @@ impl Session {
                 return Ok((handler, self));
             }
             rek => {
-                debug!("rek = {:?}", rek);
+                trace!("rek = {:?}", rek);
                 enc.rekey = rek
             }
         }
@@ -559,7 +559,7 @@ impl Session {
     ) -> Result<(H, Self), H::Error> {
         #[allow(clippy::indexing_slicing)] // length checked
         {
-            debug!(
+            trace!(
                 "authenticated buf = {:?}",
                 &buf[..std::cmp::min(buf.len(), 100)]
             );
@@ -593,7 +593,7 @@ impl Session {
                 } else {
                     Some(r.read_u32().map_err(crate::Error::from)?)
                 };
-                debug!("handler.data {:?} {:?}", ext, channel_num);
+                trace!("handler.data {:?} {:?}", ext, channel_num);
                 let data = r.read_string().map_err(crate::Error::from)?;
                 let target = self.target_window_size;
 

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -157,9 +157,12 @@ impl Encrypted {
     }
 
     pub fn adjust_window_size(&mut self, channel: ChannelId, data: &[u8], target: u32) -> bool {
-        debug!("adjust_window_size");
-        if let Some(ref mut channel) = self.channels.get_mut(&channel) {
-            debug!("channel {:?}", channel);
+        if let Some(channel) = self.channels.get_mut(&channel) {
+            trace!(
+                "adjust_window_size, channel = {}, size = {},",
+                channel.sender_channel,
+                target
+            );
             // Ignore extra data.
             // https://tools.ietf.org/html/rfc4254#section-5.2
             if data.len() as u32 <= channel.sender_window_size {
@@ -247,7 +250,7 @@ impl Encrypted {
                 #[allow(clippy::indexing_slicing)] // length checked
                 write.extend_ssh_string(&buf[..off]);
             });
-            debug!(
+            trace!(
                 "buffer: {:?} {:?}",
                 write.len(),
                 channel.recipient_window_size
@@ -258,7 +261,7 @@ impl Encrypted {
                 buf = &buf[off..]
             }
         }
-        debug!("buf.len() = {:?}, buf_len = {:?}", buf.len(), buf_len);
+        trace!("buf.len() = {:?}, buf_len = {:?}", buf.len(), buf_len);
         buf_len
     }
 
@@ -302,14 +305,14 @@ impl Encrypted {
                     #[allow(clippy::indexing_slicing)] // length checked
                     self.write.extend_ssh_string(&buf[..off]);
                 });
-                debug!("buffer: {:?}", self.write.deref().len());
+                trace!("buffer: {:?}", self.write.deref().len());
                 channel.recipient_window_size -= off as u32;
                 #[allow(clippy::indexing_slicing)] // length checked
                 {
                     buf = &buf[off..]
                 }
             }
-            debug!("buf.len() = {:?}, buf_len = {:?}", buf.len(), buf_len);
+            trace!("buf.len() = {:?}, buf_len = {:?}", buf.len(), buf_len);
             if buf_len < buf0.len() {
                 channel.pending_data.push_back((buf0, Some(ext), buf_len))
             }


### PR DESCRIPTION
Currently the "debug" level is filled with lots of verbose info about individual messages. Imo the "debug" level should contain information about state changes, while the "trace" level contains information about flowing data. That is, debug is should be useful to general consumers who want to know about connection details and reliability, while trace can be used for people who want to dig into the protocol itself :)