### PR TITLE
Adding cfg flags for the tests

### DIFF
--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -786,6 +786,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
         decode_secret_key(PKCS8_ENCRYPTED, Some("blabla")).unwrap();
     }
 
+    #[cfg(unix)]
     fn test_client_agent(key: key::KeyPair) {
         env_logger::try_init().unwrap_or(());
         use std::process::{Command, Stdio};
@@ -828,6 +829,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_client_agent_ed25519() {
         let key = decode_secret_key(ED25519_KEY, Some("blabla")).unwrap();
         test_client_agent(key)
@@ -905,9 +907,12 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
         .unwrap()
     }
 
+    #[cfg(unix)]
     struct Incoming<'a> {
         listener: &'a mut tokio::net::UnixListener,
     }
+
+    #[cfg(unix)]
     impl futures::stream::Stream for Incoming<'_> {
         type Item = Result<tokio::net::UnixStream, std::io::Error>;
 


### PR DESCRIPTION
The structure and the test that uses UnixStream is for some reason not marked as unix only, which leads to an error on windows. UnixStream is only available for unix.