### PR TITLE
Use client generated channel id when creating server initiated channel

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -650,7 +650,7 @@ impl Session {
         let (sender, receiver) = unbounded_channel();
         self.channels.insert(id, sender);
         Channel {
-            id: ChannelId(msg.recipient_channel),
+            id,
             sender: self.inbound_channel_sender.clone(),
             receiver,
             max_packet_size: msg.recipient_maximum_packet_size,

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -281,6 +281,8 @@ impl Encrypted {
             if buf_len < buf0.len() {
                 channel.pending_data.push_back((buf0, None, buf_len))
             }
+        } else {
+            debug!("{:?} not saved for this session", channel);
         }
     }
 


### PR DESCRIPTION
I am using the following to start a remote port forward (equivalent to `ssh -R`)

```rust
    if ! session.tcpip_forward("localhost", ras_session.reverse_port.into()).await? {
        anyhow::bail!("could not set tcpi-forward on remote server (-R)")
    }
```

Which then gets a callback on `server_channel_open_forwarded_tcpip`. The problem is that the channel setup in `accept_server_initiated_channel` is created with the "wrong" (?) ChannelId, which means `Session::data`, tries to get the wrong channel from `self.channels`, and fails silently when it cannot get it.

I am not entirely sure the id generated client side should be used, but this was the only way to make my forwarding work properly and receive the right channel in `server_channel_open_forwarded_tcpip`. Otherwise data written to the channel received in `server_channel_open_forwarded_tcpip` ends up in `Session::data` where it is dropped silently, since `self.channels.get_mut(&channel) ` is `None`.