### PR TITLE
Try to fix channel close issue

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -340,9 +340,7 @@ impl Session {
                 if let Some(ref mut enc) = self.common.encrypted {
                     // The CHANNEL_CLOSE message must be sent to the server at this point or the session
                     // will not be released.
-                    if enc.channels.remove(&channel_num).is_some() {
-                        enc.byte(channel_num, msg::CHANNEL_CLOSE);
-                    }
+                    enc.close(channel_num);
                 }
                 client.channel_close(channel_num, self).await
             }

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -151,6 +151,7 @@ impl Encrypted {
 
     pub fn close(&mut self, channel: ChannelId) {
         self.byte(channel, msg::CHANNEL_CLOSE);
+        self.channels.remove(&channel);
     }
 
     pub fn sender_window_size(&self, channel: ChannelId) -> usize {


### PR DESCRIPTION
This related to my comment on https://github.com/warp-tech/russh/issues/109#issuecomment-1410006553.

I managed to find the real problem.
In russh/src/client/encrypted.rs:
![image](https://user-images.githubusercontent.com/16678950/215957934-a2fa1b81-a484-4f1e-b906-49c72c8909e9.png)
When received channel close message, it removes the channel first from channel map, then send back channel_close message to server by ```Encrypted::byte``` function.
But in ```Encrypted::byte``` function, it checks the channel map to actually send the message, since it has been removed, the close message never got send to the server, this keeps the server channel leak.

![image](https://user-images.githubusercontent.com/16678950/215958581-3c91d2e9-ff79-45ba-94dd-a1b84ca26761.png)

My solution is to move remove channel in map code into ```Encrypted::close``` function.  

1. If client initiate close, ```Encrypted::close``` will be invoked, close message will be sent to server and removed in local channel map, if later received server close message, as channel has been removed, no close message will be send again.

2. If server initiate close, ```Encrypted::close``` will be invoked too, close message will be sent to server and removed in local channel map.

