### PR TITLE
Add support for `ssh-rsa` signatures in `russh-keys`

### DIFF
--- a/russh-keys/src/agent/client.rs
+++ b/russh-keys/src/agent/client.rs
@@ -402,6 +402,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
                     let sig = resp.read_string()?;
                     use crate::signature::Signature;
                     match typ {
+                        b"ssh-rsa" => Ok(Signature::RSA {
+                            bytes: sig.to_vec(),
+                            hash: SignatureHash::SHA1,
+                        }),
                         b"rsa-sha2-256" => Ok(Signature::RSA {
                             bytes: sig.to_vec(),
                             hash: SignatureHash::SHA2_256,

--- a/russh-keys/src/signature.rs
+++ b/russh-keys/src/signature.rs
@@ -76,6 +76,10 @@ impl Signature {
                 hash: SignatureHash::SHA2_512,
                 bytes: bytes.to_vec(),
             }),
+            b"ssh-rsa" => Ok(Signature::RSA {
+                hash: SignatureHash::SHA1,
+                bytes: bytes.to_vec(),
+            }),
             _ => Err(Error::UnknownSignatureType {
                 sig_type: std::str::from_utf8(typ).unwrap_or("").to_string(),
             }),


### PR DESCRIPTION
As described in #121 the current client code fails to correctly parse `ssh-rsa` signatures.

This minor patch just adds that support to parse these signatures.
