### PR TITLE
Initial client support for unix socket (direct-streamlocal) channel connections

### DIFF
--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -172,7 +172,7 @@ pub enum Msg {
         originator_port: u32,
         sender: UnboundedSender<ChannelMsg>,
     },
-    ChannelOpenDirectStream {
+    ChannelOpenDirectStreamLocal {
         socket_path: String,
         sender: UnboundedSender<ChannelMsg>,
     },
@@ -424,13 +424,13 @@ impl<H: Handler> Handle<H> {
         self.wait_channel_confirmation(receiver).await
     }
 
-    pub async fn channel_open_direct_stream<S: Into<String>>(
+    pub async fn channel_open_direct_streamlocal<S: Into<String>>(
         &self,
         socket_path: S,
     ) -> Result<Channel<Msg>, crate::Error> {
         let (sender, receiver) = unbounded_channel();
         self.sender
-            .send(Msg::ChannelOpenDirectStream {
+            .send(Msg::ChannelOpenDirectStreamLocal {
                 socket_path: socket_path.into(),
                 sender,
             })
@@ -802,11 +802,11 @@ impl Session {
                 )?;
                 self.channels.insert(id, sender);
             }
-            Msg::ChannelOpenDirectStream {
+            Msg::ChannelOpenDirectStreamLocal {
                 socket_path,
                 sender,
             } => {
-                let id = self.channel_open_direct_stream(
+                let id = self.channel_open_direct_streamlocal(
                     &socket_path,
                 )?;
                 self.channels.insert(id, sender);

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -78,6 +78,17 @@ impl Session {
         })
     }
 
+    pub fn channel_open_direct_stream(
+        &mut self,
+        socket_path: &str
+    ) -> Result<ChannelId, crate::Error> {
+        self.channel_open_generic(b"direct-streamlocal@openssh.com", |write| {
+            write.extend_ssh_string(socket_path.as_bytes());
+            write.extend_ssh_string("".as_bytes()); // reserved
+            write.push_u32_be(0); // reserved
+        })
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn request_pty(
         &mut self,

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -78,7 +78,7 @@ impl Session {
         })
     }
 
-    pub fn channel_open_direct_stream(
+    pub fn channel_open_direct_streamlocal(
         &mut self,
         socket_path: &str
     ) -> Result<ChannelId, crate::Error> {


### PR DESCRIPTION
Allow clients to initiate unix socket connections.  The method naming follows the direct_tcpip naming convention.  Updates https://github.com/warp-tech/russh/issues/108