### PR TITLE
remove all "extern crate" references and other minor changes

### DIFF
--- a/cryptovec/Cargo.toml
+++ b/cryptovec/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Pierre-Étienne Meunier <pe@pijul.org>", "Eugeny <e@ajenti.org"]
 description = "A vector which zeroes its memory on clears and reallocations."
 documentation = "https://docs.rs/russh-cryptovec"
+edition = "2018"
 include = ["Cargo.toml", "src/lib.rs"]
 license = "Apache-2.0"
 name = "russh-cryptovec"

--- a/cryptovec/src/lib.rs
+++ b/cryptovec/src/lib.rs
@@ -18,8 +18,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-extern crate libc;
-extern crate winapi;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo};
 
 use libc::c_void;

--- a/russh-keys/src/agent/client.rs
+++ b/russh-keys/src/agent/client.rs
@@ -2,6 +2,7 @@ use byteorder::{BigEndian, ByteOrder};
 use russh_cryptovec::CryptoVec;
 use tokio;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use log::{debug, info};
 
 use super::{msg, Constraint};
 use crate::encoding::{Encoding, Reader};

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+use serde_derive::{Serialize, Deserialize};
 use ed25519_dalek::ed25519::signature::Signature as EdSignature;
 use ed25519_dalek::{Signer, Verifier};
 #[cfg(feature = "openssl")]

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -172,6 +172,7 @@ impl PublicKey {
             b"ssh-rsa" | b"rsa-sha2-256" | b"rsa-sha2-512" if cfg!(feature = "openssl") => {
                 #[cfg(feature = "openssl")]
                 {
+                    use log::debug;
                     let mut p = pubkey.reader(0);
                     let key_algo = p.read_string()?;
                     debug!("{:?}", std::str::from_utf8(key_algo));

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -63,17 +63,6 @@
 //!
 //! ```
 
-#![recursion_limit = "128"]
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate thiserror;
-#[macro_use]
-extern crate log;
-
-#[cfg(test)]
-extern crate env_logger;
-
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
@@ -83,6 +72,8 @@ use aes::cipher::block_padding::UnpadError;
 use aes::cipher::inout::PadError;
 use byteorder::{BigEndian, WriteBytesExt};
 use data_encoding::BASE64_MIME;
+use thiserror::Error;
+use log::debug;
 
 pub mod encoding;
 pub mod key;
@@ -437,7 +428,6 @@ pub fn check_known_hosts(host: &str, port: u16, pubkey: &key::PublicKey) -> Resu
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
     use std::fs::File;
     use std::io::Write;
 
@@ -486,7 +476,6 @@ QR+u0AypRPmzHnOPAAAAEXJvb3RAMTQwOTExNTQ5NDBkAQ==
 
     #[test]
     fn test_decode_ed25519_secret_key() {
-        extern crate env_logger;
         env_logger::try_init().unwrap_or(());
         decode_secret_key(ED25519_KEY, Some("blabla")).unwrap();
     }
@@ -494,7 +483,6 @@ QR+u0AypRPmzHnOPAAAAEXJvb3RAMTQwOTExNTQ5NDBkAQ==
     #[test]
     #[cfg(feature = "openssl")]
     fn test_decode_rsa_secret_key() {
-        extern crate env_logger;
         env_logger::try_init().unwrap_or(());
         decode_secret_key(RSA_KEY, None).unwrap();
     }

--- a/russh-keys/src/signature.rs
+++ b/russh-keys/src/signature.rs
@@ -5,6 +5,7 @@ use serde;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeTuple;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_derive::{Serialize, Deserialize};
 
 use crate::key::SignatureHash;
 use crate::Error;

--- a/russh/examples/client.rs
+++ b/russh/examples/client.rs
@@ -1,9 +1,3 @@
-extern crate env_logger;
-extern crate futures;
-extern crate russh;
-extern crate russh_keys;
-extern crate tokio;
-
 use std::sync::Arc;
 
 use anyhow::Context;

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use russh_cryptovec::CryptoVec;
 use russh_keys::{encoding, key};
 use tokio::io::{AsyncRead, AsyncWrite};
+use bitflags::bitflags;
+use thiserror::Error;
 
 bitflags! {
     /// Set of authentication methods, represented by bit flags.

--- a/russh/src/channel_stream/mod.rs
+++ b/russh/src/channel_stream/mod.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::pin::Pin;
 use std::task::Poll;
 
+use log::debug;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 

--- a/russh/src/channels.rs
+++ b/russh/src/channels.rs
@@ -1,5 +1,6 @@
 use russh_cryptovec::CryptoVec;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver};
+use log::debug;
 
 use crate::{ChannelId, ChannelOpenFailure, ChannelStream, Error, Pty, Sig};
 

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -24,6 +24,7 @@ use byteorder::{BigEndian, ByteOrder};
 use ctr::Ctr128BE;
 use once_cell::sync::Lazy;
 use tokio::io::{AsyncRead, AsyncReadExt};
+use log::debug;
 
 use crate::mac::MacAlgorithm;
 use crate::sshbuffer::SSHBuffer;

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -18,6 +18,7 @@ use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::{Encoding, Reader};
 use russh_keys::key::parse_public_key;
 use tokio::sync::mpsc::unbounded_channel;
+use log::{debug, error, info, trace, warn};
 
 use crate::client::{Handler, Msg, Reply, Session};
 use crate::key::PubKey;

--- a/russh/src/client/kex.rs
+++ b/russh/src/client/kex.rs
@@ -1,3 +1,5 @@
+use log::{debug, trace};
+
 use crate::cipher::SealingKey;
 use crate::client::Config;
 use crate::kex::KEXES;

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -27,11 +27,6 @@
 //! when the client receives data.
 //!
 //! ```no_run
-//! extern crate russh;
-//! extern crate russh_keys;
-//! extern crate futures;
-//! extern crate tokio;
-//! extern crate env_logger;
 //! use async_trait::async_trait;
 //! use std::sync::Arc;
 //! use russh::*;
@@ -100,6 +95,7 @@ use tokio::pin;
 use tokio::sync::mpsc::{
     channel, unbounded_channel, Receiver, Sender, UnboundedReceiver, UnboundedSender,
 };
+use log::{debug, error, info, trace};
 
 use crate::channels::{Channel, ChannelMsg};
 use crate::cipher::{self, clear, CipherPair, OpeningKey};

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -1,5 +1,6 @@
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::Encoding;
+use log::error;
 
 use crate::client::Session;
 use crate::session::EncryptedState;

--- a/russh/src/kex/curve25519.rs
+++ b/russh/src/kex/curve25519.rs
@@ -1,4 +1,5 @@
 use byteorder::{BigEndian, ByteOrder};
+use log::debug;
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use curve25519_dalek::scalar::Scalar;

--- a/russh/src/kex/dh/mod.rs
+++ b/russh/src/kex/dh/mod.rs
@@ -2,6 +2,7 @@ mod groups;
 use std::marker::PhantomData;
 
 use byteorder::{BigEndian, ByteOrder};
+use log::debug;
 use digest::Digest;
 use groups::DH;
 use num_bigint::BigUint;

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -93,15 +93,10 @@
 //! starts again. In the special case of the server, unsollicited
 //! messages sent through a `server::Handle` are processed when there
 //! is no incoming packet to read.
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate thiserror;
 
 use std::fmt::{Debug, Display, Formatter};
 
+use thiserror::Error;
 use parsing::ChannelOpenConfirmation;
 pub use russh_cryptovec::CryptoVec;
 
@@ -477,7 +472,8 @@ mod test_compress {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
-
+    use log::debug;
+    
     use super::server::{Server as _, Session};
     use super::*;
     use crate::server::Msg;

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -15,6 +15,7 @@
 use std::str::from_utf8;
 
 use rand::RngCore;
+use log::debug;
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::{Encoding, Reader};
 use russh_keys::key;

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -16,6 +16,7 @@ use std::cell::RefCell;
 
 use auth::*;
 use byteorder::{BigEndian, ByteOrder};
+use log::{debug, error, info, trace, warn};
 use negotiation::Select;
 use russh_keys::encoding::{Encoding, Position, Reader};
 use russh_keys::key;

--- a/russh/src/server/kex.rs
+++ b/russh/src/server/kex.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 
 use russh_keys::encoding::{Encoding, Reader};
+use log::debug;
 
 use super::*;
 use crate::cipher::SealingKey;

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -26,10 +26,6 @@
 //! to all other clients:
 //!
 //! ```
-//! extern crate russh;
-//! extern crate russh_keys;
-//! extern crate futures;
-//! extern crate tokio;
 //! use async_trait::async_trait;
 //! use std::sync::{Mutex, Arc};
 //! use russh::*;
@@ -120,6 +116,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use log::error;
 use async_trait::async_trait;
 use futures::future::Future;
 use russh_keys::key;

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use russh_keys::encoding::Encoding;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc::{unbounded_channel, Receiver, Sender, UnboundedReceiver, UnboundedSender};
+use log::debug;
 
 use super::*;
 use crate::channels::{Channel, ChannelMsg};

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -18,6 +18,7 @@ use std::fmt::{Debug, Formatter};
 use std::num::Wrapping;
 
 use byteorder::{BigEndian, ByteOrder};
+use log::{debug, trace};
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::Encoding;
 

--- a/russh/src/ssh_read.rs
+++ b/russh/src/ssh_read.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use futures::task::*;
 use russh_cryptovec::CryptoVec;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
+use log::debug;
 
 use crate::Error;
 


### PR DESCRIPTION
- Update cryptovec's Rust edition to 2018, to match all the other russh crates.
- Remove all references to 'extern crate', which was a relic from Rust 2015.
- Remove the call to `#![recursion_limit = 128]`, as that is already the default (https://doc.rust-lang.org/reference/attributes/limits.html)

I've rebuilt and ran all tests, so hopefully this is OK.