### PR TITLE
Replace serde-derive crate with serde + the derive feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,6 @@ dependencies = [
  "rand_core 0.5.1",
  "russh-cryptovec",
  "serde",
- "serde_derive",
  "sha2 0.10.2",
  "tempdir",
  "thiserror",
@@ -1282,6 +1281,9 @@ name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -50,8 +50,7 @@ pbkdf2 = "0.11"
 rand = "0.7"
 rand_core = { version = "0.5", features = ["std"] }
 russh-cryptovec = { version = "0.7.0", path = "../cryptovec" }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"
 tokio = { version = "1.17.0", features = [

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-use serde_derive::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize};
 use ed25519_dalek::ed25519::signature::Signature as EdSignature;
 use ed25519_dalek::{Signer, Verifier};
 #[cfg(feature = "openssl")]

--- a/russh-keys/src/signature.rs
+++ b/russh-keys/src/signature.rs
@@ -5,7 +5,6 @@ use serde;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeTuple;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_derive::{Serialize, Deserialize};
 
 use crate::key::SignatureHash;
 use crate::Error;


### PR DESCRIPTION
The serde_derive crate is no longer needed.