### PR TITLE
Fix decryption of OpenSSH keys with AES CTR mode and add a test

### DIFF
--- a/russh-keys/src/format/openssh.rs
+++ b/russh-keys/src/format/openssh.rs
@@ -1,7 +1,7 @@
 use aes::cipher::block_padding::NoPadding;
 use aes::cipher::{BlockDecryptMut, KeyIvInit, StreamCipher};
 use bcrypt_pbkdf;
-use ctr::Ctr64LE;
+use ctr::Ctr64BE;
 #[cfg(feature = "openssl")]
 use openssl::bn::BigNum;
 
@@ -148,13 +148,13 @@ fn decrypt_secret_key(
             }
             b"aes128-ctr" => {
                 #[allow(clippy::unwrap_used)] // parameters are static
-                let mut cipher = Ctr64LE::<Aes128>::new_from_slices(key, iv).unwrap();
+                let mut cipher = Ctr64BE::<Aes128>::new_from_slices(key, iv).unwrap();
                 cipher.apply_keystream(&mut dec);
                 dec.truncate(secret_key.len())
             }
             b"aes256-ctr" => {
                 #[allow(clippy::unwrap_used)] // parameters are static
-                let mut cipher = Ctr64LE::<Aes256>::new_from_slices(key, iv).unwrap();
+                let mut cipher = Ctr64BE::<Aes256>::new_from_slices(key, iv).unwrap();
                 cipher.apply_keystream(&mut dec);
                 dec.truncate(secret_key.len())
             }

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -445,6 +445,16 @@ e+JpiSq66Z6GIt0801skPh20jxOO3F52SoX1IeO5D5PXfZrfSZlw6S8c7bwyp2FHxDewRx
 7/wNsnDM0T7nLv/Q==
 -----END OPENSSH PRIVATE KEY-----";
 
+    // password is 'test'
+    const ED25519_AESCTR_KEY: &str = "-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABD1phlku5
+A2G7Q9iP+DcOc9AAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIHeLC1lWiCYrXsf/
+85O/pkbUFZ6OGIt49PX3nw8iRoXEAAAAkKRF0st5ZI7xxo9g6A4m4l6NarkQre3mycqNXQ
+dP3jryYgvsCIBAA5jMWSjrmnOTXhidqcOy4xYCrAttzSnZ/cUadfBenL+DQq6neffw7j8r
+0tbCxVGp6yCQlKrgSZf6c0Hy7dNEIU2bJFGxLe6/kWChcUAt/5Ll5rI7DVQPJdLgehLzvv
+sJWR7W+cGvJ/vLsw==
+-----END OPENSSH PRIVATE KEY-----";
+
     #[cfg(feature = "openssl")]
     const RSA_KEY: &str = "-----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
@@ -478,6 +488,12 @@ QR+u0AypRPmzHnOPAAAAEXJvb3RAMTQwOTExNTQ5NDBkAQ==
     fn test_decode_ed25519_secret_key() {
         env_logger::try_init().unwrap_or(());
         decode_secret_key(ED25519_KEY, Some("blabla")).unwrap();
+    }
+
+    #[test]
+    fn test_decode_ed25519_aesctr_secret_key() {
+        env_logger::try_init().unwrap_or(());
+        decode_secret_key(ED25519_AESCTR_KEY, Some("test")).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
russh-keys was unable to decrypt ssh key files encrypted with AES in CTR mode, due to the counter being set to little endian format.  This changes the counter to big endian and adds a test with a key encrypted in AES CTR mode.  The existing test only covered the AES CBC case.