### PR TITLE
correct initial fix for issue 143 (channel open failure on remote port forwarding)

### DIFF
--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -259,6 +259,9 @@ impl Handle {
                         window_size,
                     });
                 }
+                Some(ChannelMsg::OpenFailure(reason)) => {
+                    return Err(Error::ChannelOpenFailure(reason))
+                }
                 None => {
                     return Err(Error::Disconnect);
                 }


### PR DESCRIPTION
Hello. Thank you for your reply and merge, happy to help!
I realized that my initial solution didn't address the problem correctly. It was only replying to client with the same error code.

This new patch send `ChannelMsg::OpenFailure` as a response to `Handle::wait_channel_confirmation` which can then return an error as `Err(Error::ChannelOpenFailure(reason))` to `Handle::channel_open_forwarded_tcpip`.

This has effectively fixed my own project and the method is not stuck anymore. Sorry for the mistake, I'm quite new on this project so I will take time to read the code in the future.