### PR TITLE
Keyboard interactive auth

### DIFF
--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -100,6 +100,7 @@ pub enum Method {
     Password { password: String },
     PublicKey { key: Arc<key::KeyPair> },
     FuturePublicKey { key: key::PublicKey },
+    KeyboardInteractive { submethods: String },
     // Hostbased,
 }
 
@@ -150,3 +151,4 @@ pub enum CurrentRequest {
         submethods: String,
     },
 }
+

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -307,9 +307,7 @@ impl Session {
                             // write responses
                             enc.client_send_auth_response(&responses)?;
                             return Ok((client, self));
-                        } else {
-                            unreachable!()
-                        }
+                        } else {}
 
                         // continue with userauth_pk_ok
                         match self.common.auth_method.take() {

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -264,7 +264,6 @@ impl Session {
                         // write responses 
                         enc.client_send_auth_response(&responses)?;
 
-                        return Ok((client, self));
                     } else if buf.first() == Some(&msg::USERAUTH_INFO_REQUEST_OR_USERAUTH_PK_OK) {
                         debug!("userauth_pk_ok");
                         if let Some(auth::CurrentRequest::PublicKey {
@@ -866,7 +865,7 @@ impl Encrypted {
     ) -> Result<(), crate::Error> {
         push_packet!(self.write, {
             self.write.push(msg::USERAUTH_INFO_RESPONSE);
-            self.write.push(responses.len().try_into().unwrap_or(0)); // number of responses
+            self.write.push_u32_be(responses.len().try_into().unwrap_or(0)); // number of responses
             for r in responses {
                 self.write.extend_ssh_string(r.as_bytes()); // write the reponses
             }

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -282,9 +282,9 @@ impl<H: Handler> Handle<H> {
         self.wait_recv_reply().await
     }
 
-    /// Perform keyboard-interactive-based SSH authentication.
+    /// Initiate Keyboard-Interactive based SSH authentication.
     ///
-    /// * `submethods` - Hnts to the server the preffered methods to be used for authentication
+    /// * `submethods` - Hnts to the server the preferred methods to be used for authentication
     pub async fn authenticate_keyboard_interactive_start<
         U: Into<String>,
         S: Into<Option<String>>,
@@ -305,6 +305,12 @@ impl<H: Handler> Handle<H> {
         self.wait_recv_keyboard_interactive_reply().await
     }
 
+    /// Respond to AuthInfoRequests from the server. A server can send any number of these Requests
+    /// including empty requests. You may have to call this function multple times in order to 
+    /// complete Keyboard-Interactive based SSH authentication.
+    ///
+    /// * `responses` - The responses to each prompt. The number of responses must match the number
+    /// of prompts. If a prompt has an empty string, then the response should be an empty string.
     pub async fn authenticate_keyboard_interactive_respond(
         &mut self,
         responses: Vec<String>,

--- a/russh/src/msg.rs
+++ b/russh/src/msg.rs
@@ -42,6 +42,9 @@ pub const USERAUTH_PK_OK: u8 = 60;
 pub const USERAUTH_INFO_REQUEST: u8 = 60;
 pub const USERAUTH_INFO_RESPONSE: u8 = 61;
 
+// some numbers have same meaning
+pub const USERAUTH_INFO_REQUEST_OR_USERAUTH_PK_OK: u8 = 60;
+
 // https://tools.ietf.org/html/rfc4254#section-9
 pub const GLOBAL_REQUEST: u8 = 80;
 pub const REQUEST_SUCCESS: u8 = 81;


### PR DESCRIPTION

So I had some time to work on this. I think I am in  little over my head here, but maybe you can point me in the right direction. I may just need to stare at the codebase longer, but this is what I have so far.

So it sends a Keyboard-Interactive request and receives the AuthInfoRequest that contains the challenges. The user is given a trait to implement in order to fulfill those challenges/prompts. The results of are then sent back to the Auth request and written to the buffer. I think I am definitely missing something important here because after that the session and handle gets dropped. What should happen next is that the server send another AuthInfoRequest, AuthSuccess or AuthFailure. It's almost like client_encrypted_read needs to be called again.

Another thing is that USERAUTH_PK_OK and USERAUTH_INFO_REQUEST share the same number. For the sake of testing just keyboard interactive, I have it in an else-if before PK_OK. At some point I need to differentiate between the two. I noticed that auth_request.current can hold a CurrentRequest that has a KeyboardInteractive variant, but I am unsure of where that should get set.

I appreciate any direction you can give me. I think I don't yet have a clear understanding of the over flow of the code yet.