### PR TITLE
Handle tcp-ip-forward global request responses.

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -559,6 +559,20 @@ impl Session {
                 }
                 Ok((client, self))
             }
+            Some(&msg::REQUEST_SUCCESS) => {
+                let mut r = buf.reader(1);
+                let port_num = r.read_u32().map_err(crate::Error::from)?;
+                self.sender
+                    .send(Reply::GlobalRequestSuccess(port_num))
+                    .map_err(|_| crate::Error::SendError)?;
+                Ok((client, self))
+            }
+            Some(&msg::REQUEST_FAILURE) => {
+                self.sender
+                    .send(Reply::GlobalRequestFailure)
+                    .map_err(|_| crate::Error::SendError)?;
+                Ok((client, self))
+            }
             Some(&msg::CHANNEL_SUCCESS) => {
                 let mut r = buf.reader(1);
                 let channel_num = ChannelId(r.read_u32().map_err(crate::Error::from)?);

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -266,6 +266,9 @@ pub enum Error {
     #[error("Failed to decrypt a packet")]
     DecryptionError,
 
+    #[error("Global request failed")]
+    GlobalRequestFailure,
+
     #[error(transparent)]
     Keys(#[from] russh_keys::Error),
 


### PR DESCRIPTION
When a tcp-ip-forward global request is sent a REQUEST_SUCCESS or a REQUEST_FAILURE response is expected and should be handled. this is also an opportunity to parse and return the port number returned by the server.