### PR TITLE
Use v2 of `cargo-semver-checks-action`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,9 @@ jobs:
       run: cargo build --verbose --all-features
 
     - name: Check semver compatibility (russh)
-      uses: obi1kenobi/cargo-semver-checks-action@v1
+      uses: obi1kenobi/cargo-semver-checks-action@v2
       with:
-        crate-name: russh
+        package: russh
 
   Clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi! As one of the contributors of cargo-semver-checks I'd want to say we're pleased to see you're using our tool!

Since we've recently released a new, completely rebuilt version of the GitHub action, I suggest using it instead of the outdated V1. It not only fixes the problems with choosing the baseline version, but also includes several improvements of the running time, which result in huge speedup of `Check semver compatibility (russh)` step: ~1m 40s compared to previous 7 minutes.

By default, the action uses the latest stable toolchain to run the checks.  This ensures we use the latest version of rustdoc, taking advantage of the latest bugfixes and avoiding false-positives. If you want to change this behavior and use Rust 1.65.0 as specified in `rust-toolchain.toml` file, you have to additionally pass the input `rust-toolchain: manual`. Or just let me know and I'll add such a change in this PR ;)