### PR TITLE
Error::UnsupportedKeyType holds a String

### DIFF
--- a/russh-keys/src/format/mod.rs
+++ b/russh-keys/src/format/mod.rs
@@ -76,7 +76,10 @@ pub fn decode_secret_key(secret: &str, password: Option<&str>) -> Result<key::Ke
             } else if l == "-----BEGIN RSA PRIVATE KEY-----" {
                 #[cfg(not(feature = "openssl"))]
                 {
-                    return Err(Error::UnsupportedKeyType("rsa".as_bytes().to_vec()));
+                    return Err(Error::UnsupportedKeyType {
+                        key_type_string: "rsa".to_owned(),
+                        key_type_raw: "rsa".as_bytes().to_vec(),
+                    });
                 }
                 #[cfg(feature = "openssl")]
                 {

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -72,8 +72,8 @@ use aes::cipher::block_padding::UnpadError;
 use aes::cipher::inout::PadError;
 use byteorder::{BigEndian, WriteBytesExt};
 use data_encoding::BASE64_MIME;
-use thiserror::Error;
 use log::debug;
+use thiserror::Error;
 
 pub mod encoding;
 pub mod key;
@@ -91,8 +91,11 @@ pub enum Error {
     #[error("Could not read key")]
     CouldNotReadKey,
     /// The type of the key is unsupported
-    #[error("Unsupported key type")]
-    UnsupportedKeyType(Vec<u8>),
+    #[error("Unsupported key type {}", key_type_string)]
+    UnsupportedKeyType {
+        key_type_string: String,
+        key_type_raw: Vec<u8>,
+    },
     /// The type of the key is unsupported
     #[error("Invalid Ed25519 key data")]
     Ed25519KeyError(#[from] ed25519_dalek::SignatureError),


### PR DESCRIPTION
Previously errors looked like: `UnsupportedKeyType([114, 115, 97])`
But with this PR they now look like: `UnsupportedKeyType("rsa")`