### PR TITLE
Trait method to add conditions for SSH agent server when accepting requests for operations 

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -29,6 +29,7 @@ version = "0.37.1"
 
 [dependencies]
 aes = "0.8"
+async-trait = "0.1.72"
 bcrypt-pbkdf = "0.9"
 bit-vec = "0.6"
 cbc = "0.1"

--- a/russh-keys/src/agent/server.rs
+++ b/russh-keys/src/agent/server.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
 
+use async_trait::async_trait;
 use byteorder::{BigEndian, ByteOrder};
 use futures::future::Future;
 use futures::stream::{Stream, StreamExt};
@@ -30,12 +31,17 @@ pub enum ServerError<E> {
     Error(Error),
 }
 
+#[async_trait]
 pub trait Agent: Clone + Send + 'static {
     fn confirm(
         self,
         _pk: Arc<key::KeyPair>,
     ) -> Box<dyn Future<Output = (Self, bool)> + Unpin + Send> {
         Box::new(futures::future::ready((self, true)))
+    }
+
+    async fn confirm_request(&self) -> bool {
+        true
     }
 }
 

--- a/russh-keys/src/agent/server.rs
+++ b/russh-keys/src/agent/server.rs
@@ -131,87 +131,88 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
         };
         writebuf.extend(&[0, 0, 0, 0]);
         let mut r = self.buf.reader(0);
-        let agentref = self.agent.as_ref().expect("");
-        match r.read_byte() {
-            Ok(11) if !is_locked && agentref.confirm_request(MessageType::RequestKeys).await => {
-                // request identities
-                if let Ok(keys) = self.keys.0.read() {
-                    writebuf.push(msg::IDENTITIES_ANSWER);
-                    writebuf.push_u32_be(keys.len() as u32);
-                    for (k, _) in keys.iter() {
-                        writebuf.extend_ssh_string(k);
-                        writebuf.extend_ssh_string(b"");
+        if let Some(agentref) = self.agent.as_ref() {
+            match r.read_byte() {
+                Ok(11) if !is_locked && agentref.confirm_request(MessageType::RequestKeys).await => {
+                    // request identities
+                    if let Ok(keys) = self.keys.0.read() {
+                        writebuf.push(msg::IDENTITIES_ANSWER);
+                        writebuf.push_u32_be(keys.len() as u32);
+                        for (k, _) in keys.iter() {
+                            writebuf.extend_ssh_string(k);
+                            writebuf.extend_ssh_string(b"");
+                        }
+                    } else {
+                        writebuf.push(msg::FAILURE)
                     }
-                } else {
+                }
+                Ok(13) if !is_locked && agentref.confirm_request(MessageType::Sign).await => {
+                    // sign request
+                    let agent = self.agent.take().ok_or(Error::AgentFailure)?;
+                    let (agent, signed) = self.try_sign(agent, r, writebuf).await?;
+                    self.agent = Some(agent);
+                    if signed {
+                        return Ok(());
+                    } else {
+                        writebuf.resize(4);
+                        writebuf.push(msg::FAILURE)
+                    }
+                }
+                Ok(17) if !is_locked && agentref.confirm_request(MessageType::AddKeys).await => {
+                    // add identity
+                    if let Ok(true) = self.add_key(r, false, writebuf).await {
+                    } else {
+                        writebuf.push(msg::FAILURE)
+                    }
+                }
+                Ok(18) if !is_locked && agentref.confirm_request(MessageType::RemoveKeys).await => {
+                    // remove identity
+                    if let Ok(true) = self.remove_identity(r) {
+                        writebuf.push(msg::SUCCESS)
+                    } else {
+                        writebuf.push(msg::FAILURE)
+                    }
+                }
+                Ok(19) if !is_locked && agentref.confirm_request(MessageType::RemoveAllKeys).await => {
+                    // remove all identities
+                    if let Ok(mut keys) = self.keys.0.write() {
+                        keys.clear();
+                        writebuf.push(msg::SUCCESS)
+                    } else {
+                        writebuf.push(msg::FAILURE)
+                    }
+                }
+                Ok(22) if !is_locked && agentref.confirm_request(MessageType::Lock).await => {
+                    // lock
+                    if let Ok(()) = self.lock(r) {
+                        writebuf.push(msg::SUCCESS)
+                    } else {
+                        writebuf.push(msg::FAILURE)
+                    }
+                }
+                Ok(23) if is_locked && agentref.confirm_request(MessageType::Unlock).await => {
+                    // unlock
+                    if let Ok(true) = self.unlock(r) {
+                        writebuf.push(msg::SUCCESS)
+                    } else {
+                        writebuf.push(msg::FAILURE)
+                    }
+                }
+                Ok(25) if !is_locked && agentref.confirm_request(MessageType::AddKeys).await => {
+                    // add identity constrained
+                    if let Ok(true) = self.add_key(r, true, writebuf).await {
+                    } else {
+                        writebuf.push(msg::FAILURE)
+                    }
+                }
+                _ => {
+                    // Message not understood
                     writebuf.push(msg::FAILURE)
                 }
             }
-            Ok(13) if !is_locked && agentref.confirm_request(MessageType::Sign).await => {
-                // sign request
-                let agent = self.agent.take().ok_or(Error::AgentFailure)?;
-                let (agent, signed) = self.try_sign(agent, r, writebuf).await?;
-                self.agent = Some(agent);
-                if signed {
-                    return Ok(());
-                } else {
-                    writebuf.resize(4);
-                    writebuf.push(msg::FAILURE)
-                }
-            }
-            Ok(17) if !is_locked && agentref.confirm_request(MessageType::AddKeys).await => {
-                // add identity
-                if let Ok(true) = self.add_key(r, false, writebuf).await {
-                } else {
-                    writebuf.push(msg::FAILURE)
-                }
-            }
-            Ok(18) if !is_locked && agentref.confirm_request(MessageType::RemoveKeys).await => {
-                // remove identity
-                if let Ok(true) = self.remove_identity(r) {
-                    writebuf.push(msg::SUCCESS)
-                } else {
-                    writebuf.push(msg::FAILURE)
-                }
-            }
-            Ok(19) if !is_locked && agentref.confirm_request(MessageType::RemoveAllKeys).await => {
-                // remove all identities
-                if let Ok(mut keys) = self.keys.0.write() {
-                    keys.clear();
-                    writebuf.push(msg::SUCCESS)
-                } else {
-                    writebuf.push(msg::FAILURE)
-                }
-            }
-            Ok(22) if !is_locked && agentref.confirm_request(MessageType::Lock).await => {
-                // lock
-                if let Ok(()) = self.lock(r) {
-                    writebuf.push(msg::SUCCESS)
-                } else {
-                    writebuf.push(msg::FAILURE)
-                }
-            }
-            Ok(23) if is_locked && agentref.confirm_request(MessageType::Unlock).await => {
-                // unlock
-                if let Ok(true) = self.unlock(r) {
-                    writebuf.push(msg::SUCCESS)
-                } else {
-                    writebuf.push(msg::FAILURE)
-                }
-            }
-            Ok(25) if !is_locked && agentref.confirm_request(MessageType::AddKeys).await => {
-                // add identity constrained
-                if let Ok(true) = self.add_key(r, true, writebuf).await {
-                } else {
-                    writebuf.push(msg::FAILURE)
-                }
-            }
-            _ => {
-                // Message not understood
-                writebuf.push(msg::FAILURE)
-            }
+            let len = writebuf.len() - 4;
+            BigEndian::write_u32(&mut writebuf[..], len as u32);
         }
-        let len = writebuf.len() - 4;
-        BigEndian::write_u32(&mut writebuf[..], len as u32);
         Ok(())
     }
 


### PR DESCRIPTION
Fix #165 

The `russh_keys::agent::server::Agent` trait now has another async trait we can define if necessary which will check if we should be able to perform a given operation or not. External developers can implement this trait method with their own code, allowing the request to fail if necessary.

The operation types are represented in a newly created `MessageType` enum and passed into this new method. By default, the method returns true, so old code shouldn't be affected by this change.