### PR TITLE
Update dependencies

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -30,14 +30,14 @@ version = "0.37.1"
 [dependencies]
 aes = "0.8"
 async-trait = "0.1.72"
-bcrypt-pbkdf = "0.9"
+bcrypt-pbkdf = "0.10"
 bit-vec = "0.6"
 cbc = "0.1"
 ctr = "0.9"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder = "1.4"
 data-encoding = "2.3"
-dirs = "4.0"
+dirs = "5.0"
 ed25519-dalek = "1.0"
 futures = "0.3"
 hmac = "0.12"
@@ -67,5 +67,5 @@ yasna = { version = "0.5.0", features = ["bit-vec", "num-bigint"] }
 vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.10"
 tempdir = "0.3"

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -21,10 +21,10 @@ vendored-openssl = ["openssl/vendored", "russh-keys/vendored-openssl"]
 aes = "0.8"
 aes-gcm = "0.10"
 async-trait = "0.1"
-bitflags = "1.2"
+bitflags = "2.0"
 byteorder = "1.3"
 chacha20 = "0.9"
-curve25519-dalek = "3.2"
+curve25519-dalek = "4.0"
 poly1305 = "0.8"
 ctr = "0.9"
 digest = "0.10"
@@ -40,7 +40,7 @@ russh-cryptovec = { version = "0.7.0", path = "../cryptovec" }
 russh-keys = { version = "0.37.1", path = "../russh-keys" }
 sha1 = "0.10"
 sha2 = "0.10"
-hex-literal = "0.3"
+hex-literal = "0.4"
 num-bigint = { version = "0.4", features = ["rand"] }
 subtle = "2.4"
 thiserror = "1.0"
@@ -57,7 +57,7 @@ tokio-util = "0.7"
 
 [dev-dependencies]
 anyhow = "1.0"
-env_logger = "0.9"
+env_logger = "0.10"
 tokio = { version = "1.17.0", features = [
     "io-util",
     "rt-multi-thread",

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -15,14 +15,15 @@
 
 use std::sync::Arc;
 
+use bitflags::bitflags;
 use russh_cryptovec::CryptoVec;
 use russh_keys::{encoding, key};
-use tokio::io::{AsyncRead, AsyncWrite};
-use bitflags::bitflags;
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 bitflags! {
     /// Set of authentication methods, represented by bit flags.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct MethodSet: u32 {
         /// The SSH `none` method (no authentication).
         const NONE = 1;
@@ -38,27 +39,6 @@ bitflags! {
         /// challenge, where the "challenge" can be a password prompt,
         /// a bytestring to sign with a smartcard, or something else).
         const KEYBOARD_INTERACTIVE = 16;
-    }
-}
-
-macro_rules! iter {
-    ( $y:expr, $x:expr ) => {{
-        if $y.contains($x) {
-            $y.remove($x);
-            return Some($x);
-        }
-    }};
-}
-
-impl Iterator for MethodSet {
-    type Item = MethodSet;
-    fn next(&mut self) -> Option<MethodSet> {
-        iter!(self, MethodSet::NONE);
-        iter!(self, MethodSet::PASSWORD);
-        iter!(self, MethodSet::PUBLICKEY);
-        iter!(self, MethodSet::HOSTBASED);
-        iter!(self, MethodSet::KEYBOARD_INTERACTIVE);
-        None
     }
 }
 
@@ -151,4 +131,3 @@ pub enum CurrentRequest {
         submethods: String,
     },
 }
-

--- a/russh/src/kex/curve25519.rs
+++ b/russh/src/kex/curve25519.rs
@@ -1,8 +1,8 @@
 use byteorder::{BigEndian, ByteOrder};
-use log::debug;
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use curve25519_dalek::scalar::Scalar;
+use log::debug;
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::Encoding;
 
@@ -72,7 +72,7 @@ impl KexAlgorithm for Curve25519Kex {
         };
 
         let server_secret = Scalar::from_bytes_mod_order(rand::random::<[u8; 32]>());
-        let server_pubkey = (&ED25519_BASEPOINT_TABLE * &server_secret).to_montgomery();
+        let server_pubkey = (ED25519_BASEPOINT_TABLE * &server_secret).to_montgomery();
 
         // fill exchange.
         exchange.server_ephemeral.clear();
@@ -89,7 +89,7 @@ impl KexAlgorithm for Curve25519Kex {
         buf: &mut CryptoVec,
     ) -> Result<(), crate::Error> {
         let client_secret = Scalar::from_bytes_mod_order(rand::random::<[u8; 32]>());
-        let client_pubkey = (&ED25519_BASEPOINT_TABLE * &client_secret).to_montgomery();
+        let client_pubkey = (ED25519_BASEPOINT_TABLE * &client_secret).to_montgomery();
 
         // fill exchange.
         client_ephemeral.clear();

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -496,7 +496,7 @@ async fn reject_auth_request(
     debug!("rejecting {:?}", auth_request);
     push_packet!(write, {
         write.push(msg::USERAUTH_FAILURE);
-        write.extend_list(auth_request.methods);
+        write.extend_list(auth_request.methods.into_iter());
         write.push(auth_request.partial_success as u8);
     });
     auth_request.current = None;


### PR DESCRIPTION
Notes:
* It seems appropriate to just unwrap the result of `pbkdf2` since I assume it was previously just panicking internally on such a case.
* bitflags 2.0 now automatically implements IntoIterator, removing the need for manually implementing Iterator. It also requires us to Derive a bunch of traits ourselves that used to be done automatically.
* a change in curve25519-dalek resulted in a previous double reference failing to automatically dereference. Not sure why that is but changing it to a single reference makes more sense anyway.
* I left the rand in russh-keys as is because that version of rand is used in the ed25519-dalek api.