### PR TITLE
Use `ChannelMsg::WindowAdjusted` during data transfer

### DIFF
--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -47,7 +47,7 @@ impl Session {
         // Either this packet is a KEXINIT, in which case we start a key re-exchange.
 
         #[allow(clippy::unwrap_used)]
-        let mut enc = self.common.encrypted.as_mut().unwrap();
+        let enc = self.common.encrypted.as_mut().unwrap();
         if buf.first() == Some(&msg::KEXINIT) {
             debug!("Received rekeying request");
             // If we're not currently rekeying, but `buf` is a rekey request
@@ -143,7 +143,7 @@ impl Session {
         };
 
         #[allow(clippy::unwrap_used)]
-        let mut enc = self.common.encrypted.as_mut().unwrap();
+        let enc = self.common.encrypted.as_mut().unwrap();
         // If we've successfully read a packet.
         match enc.state {
             EncryptedState::WaitingAuthServiceRequest {


### PR DESCRIPTION
OpenSSH server sends `CHANNEL_WINDOW_ADJUST` messages before window_size is 0.

Handle these messages at each turn of the loop within `Channel.send_data`

Fixes #179
