### PR TITLE
bumb toolchain & add sftp client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is a fork of [Thrussh](https://nest.pijul.com/pijul/thrussh) by Pierre-Éti
 
 ## Ecosystem
 
-* [russh-sftp](https://crates.io/crates/russh-sftp) - server-side SFTP subsystem support for `russh` - see `russh/examples/sftp_server.rs`.
+* [russh-sftp](https://crates.io/crates/russh-sftp) - server-side and client-side SFTP subsystem support for `russh` - see `russh/examples/sftp_server.rs` or `russh/examples/sftp_client.rs`.
 * [async-ssh2-tokio](https://crates.io/crates/async-ssh2-tokio) - simple high-level API for running commands over SSH.
 
 ## Contributors ✨

--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -93,18 +93,13 @@ pub fn parse_path<P: AsRef<Path>>(path: P, host: &str) -> Result<Config, Error> 
     parse(&s, host)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum AddKeysToAgent {
     Yes,
     Confirm,
     Ask,
+    #[default]
     No,
-}
-
-impl Default for AddKeysToAgent {
-    fn default() -> Self {
-        AddKeysToAgent::No
-    }
 }
 
 pub fn parse(file: &str, host: &str) -> Result<Config, Error> {

--- a/russh-keys/src/agent/server.rs
+++ b/russh-keys/src/agent/server.rs
@@ -262,7 +262,8 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
                 #[allow(clippy::indexing_slicing)] // length checked before
                 let secret = ed25519_dalek::SigningKey::try_from(
                     concat.get(..32).ok_or(Error::KeyIsCorrupt)?,
-                ).map_err(|_| Error::KeyIsCorrupt)?;
+                )
+                .map_err(|_| Error::KeyIsCorrupt)?;
 
                 writebuf.push(msg::SUCCESS);
 
@@ -369,7 +370,7 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
         let key = {
             let blob = r.read_string()?;
             let k = self.keys.0.read().or(Err(Error::AgentFailure))?;
-            if let Some(&(ref key, _, ref constraints)) = k.get(blob) {
+            if let Some((key, _, constraints)) = k.get(blob) {
                 if constraints.iter().any(|c| *c == Constraint::Confirm) {
                     needs_confirm = true;
                 }

--- a/russh-keys/src/format/pkcs8.rs
+++ b/russh-keys/src/format/pkcs8.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::convert::TryFrom;
 
 use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
 use bit_vec::BitVec;
@@ -9,7 +10,6 @@ use openssl::pkey::Private;
 use openssl::rsa::Rsa;
 #[cfg(test)]
 use rand_core::OsRng;
-use std::convert::TryFrom;
 use yasna::BERReaderSeq;
 use {std, yasna};
 

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+use std::convert::TryFrom;
+
 use ed25519_dalek::{Signer, Verifier};
 #[cfg(feature = "openssl")]
 use openssl::pkey::{Private, Public};
 use rand_core::OsRng;
 use russh_cryptovec::CryptoVec;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 
 use crate::encoding::{Encoding, Reader};
 pub use crate::signature::*;

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -434,7 +434,7 @@ mod test {
     use std::fs::File;
     use std::io::Write;
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(unix, feature = "openssl"))]
     use futures::Future;
 
     use super::*;
@@ -843,14 +843,14 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
+    #[cfg(all(unix, feature = "openssl"))]
     fn test_client_agent_rsa() {
         let key = decode_secret_key(PKCS8_ENCRYPTED, Some("blabla")).unwrap();
         test_client_agent(key)
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
+    #[cfg(all(unix, feature = "openssl"))]
     fn test_client_agent_openssh_rsa() {
         let key = decode_secret_key(RSA_KEY, None).unwrap();
         test_client_agent(key)

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -283,9 +283,9 @@ pub fn load_secret_key<P: AsRef<Path>>(
 }
 
 fn is_base64_char(c: char) -> bool {
-    ('a'..='z').contains(&c)
-        || ('A'..='Z').contains(&c)
-        || ('0'..='9').contains(&c)
+    c.is_ascii_lowercase()
+        || c.is_ascii_uppercase()
+        || c.is_ascii_digit()
         || c == '/'
         || c == '+'
         || c == '='
@@ -413,7 +413,7 @@ pub fn check_known_hosts(host: &str, port: u16, pubkey: &key::PublicKey) -> Resu
         known_host_file.push("known_hosts");
         check_known_hosts_path(host, port, pubkey, &known_host_file)
     } else {
-        Err(Error::NoHomeDir.into())
+        Err(Error::NoHomeDir)
     }
 }
 

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1.17.0", features = [
     "sync",
     "macros",
 ] }
-russh-sftp = "2.0.0-beta.1"
+russh-sftp = "2.0.0-beta.2"
 
 [package.metadata.docs.rs]
 features = ["openssl"]

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1.17.0", features = [
     "sync",
     "macros",
 ] }
-russh-sftp = "1.1"
+russh-sftp = "2.0.0-beta.1"
 
 [package.metadata.docs.rs]
 features = ["openssl"]

--- a/russh/examples/sftp_client.rs
+++ b/russh/examples/sftp_client.rs
@@ -1,9 +1,10 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use log::{error, info, LevelFilter};
 use russh::*;
 use russh_keys::*;
 use russh_sftp::client::SftpSession;
-use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 struct Client;

--- a/russh/examples/sftp_client.rs
+++ b/russh/examples/sftp_client.rs
@@ -1,0 +1,102 @@
+use async_trait::async_trait;
+use log::{error, info, LevelFilter};
+use russh::*;
+use russh_keys::*;
+use russh_sftp::client::SftpSession;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
+struct Client;
+
+#[async_trait]
+impl client::Handler for Client {
+    type Error = anyhow::Error;
+
+    async fn check_server_key(
+        self,
+        server_public_key: &key::PublicKey,
+    ) -> Result<(Self, bool), Self::Error> {
+        info!("check_server_key: {:?}", server_public_key);
+        Ok((self, true))
+    }
+
+    async fn data(
+        self,
+        channel: ChannelId,
+        data: &[u8],
+        session: client::Session,
+    ) -> Result<(Self, client::Session), Self::Error> {
+        info!("data on channel {:?}: {}", channel, data.len());
+        Ok((self, session))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::builder()
+        .filter_level(LevelFilter::Debug)
+        .init();
+
+    let config = russh::client::Config::default();
+    let sh = Client {};
+    let mut session = russh::client::connect(Arc::new(config), ("localhost", 22), sh)
+        .await
+        .unwrap();
+    if session.authenticate_password("root", "pass").await.unwrap() {
+        let mut channel = session.channel_open_session().await.unwrap();
+        channel.request_subsystem(true, "sftp").await.unwrap();
+        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
+        info!("current path: {:?}", sftp.canonicalize(".").await.unwrap());
+
+        // create dir and symlink
+        let path = "./some_kind_of_dir";
+        let symlink = "./symlink";
+
+        sftp.create_dir(path).await.unwrap();
+        sftp.symlink(path, symlink).await.unwrap();
+
+        info!("dir info: {:?}", sftp.metadata(path).await.unwrap());
+        info!(
+            "symlink info: {:?}",
+            sftp.symlink_metadata(path).await.unwrap()
+        );
+
+        // scanning directory
+        for entry in sftp.read_dir(".").await.unwrap() {
+            info!("file in directory: {:?}", entry.file_name());
+        }
+
+        sftp.remove_file(symlink).await.unwrap();
+        sftp.remove_dir(path).await.unwrap();
+
+        // interaction with i/o
+        let filename = "test_new.txt";
+        let mut file = sftp.create(filename).await.unwrap();
+        info!("metadata by handle: {:?}", file.metadata().await.unwrap());
+
+        file.write_all(b"magic text").await.unwrap();
+        info!("flush: {:?}", file.flush().await); // or file.sync_all()
+        info!(
+            "current cursor position: {:?}",
+            file.stream_position().await
+        );
+
+        let mut str = String::new();
+
+        file.rewind().await.unwrap();
+        file.read_to_string(&mut str).await.unwrap();
+        file.rewind().await.unwrap();
+
+        info!(
+            "our magical contents: {}, after rewind: {:?}",
+            str,
+            file.stream_position().await
+        );
+
+        file.shutdown().await.unwrap();
+        sftp.remove_file(filename).await.unwrap();
+
+        // should fail because handle was closed
+        error!("should fail: {:?}", file.read_u8().await);
+    }
+}

--- a/russh/examples/sftp_server.rs
+++ b/russh/examples/sftp_server.rs
@@ -151,10 +151,12 @@ impl russh_sftp::server::Handler for SftpSession {
                 files: vec![
                     File {
                         filename: "foo".to_string(),
+                        longname: "".to_string(),
                         attrs: FileAttributes::default(),
                     },
                     File {
                         filename: "bar".to_string(),
+                        longname: "".to_string(),
                         attrs: FileAttributes::default(),
                     },
                 ],
@@ -169,6 +171,7 @@ impl russh_sftp::server::Handler for SftpSession {
             id,
             files: vec![File {
                 filename: "/".to_string(),
+                longname: "".to_string(),
                 attrs: FileAttributes::default(),
             }],
         })
@@ -185,7 +188,6 @@ async fn main() {
         auth_rejection_time: Duration::from_secs(3),
         auth_rejection_time_initial: Some(Duration::from_secs(0)),
         keys: vec![KeyPair::generate_ed25519().unwrap()],
-        inactivity_timeout: Some(Duration::from_secs(3600)),
         ..Default::default()
     };
 

--- a/russh/examples/sftp_server.rs
+++ b/russh/examples/sftp_server.rs
@@ -1,12 +1,14 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use log::{error, info, LevelFilter};
-use russh::{
-    server::{Auth, Msg, Session},
-    Channel, ChannelId,
-};
+use russh::server::{Auth, Msg, Session};
+use russh::{Channel, ChannelId};
 use russh_keys::key::KeyPair;
 use russh_sftp::protocol::{File, FileAttributes, Handle, Name, Status, StatusCode, Version};
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
 #[derive(Clone)]

--- a/russh/examples/test.rs
+++ b/russh/examples/test.rs
@@ -1,11 +1,11 @@
-use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
+use async_trait::async_trait;
 use log::debug;
 use russh::server::{Auth, Msg, Session};
 use russh::*;
 use russh_keys::*;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/russh/src/channel_stream/mod.rs
+++ b/russh/src/channel_stream/mod.rs
@@ -103,7 +103,7 @@ impl AsyncWrite for ChannelStream {
     ) -> Poll<Result<(), io::Error>> {
         if let Err(err) = self.outgoing.send("".into()) {
             let err = format!("{err:?}");
-            return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, err)))
+            return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, err)));
         }
         Poll::Ready(Ok(()))
     }

--- a/russh/src/channels.rs
+++ b/russh/src/channels.rs
@@ -1,6 +1,6 @@
+use log::debug;
 use russh_cryptovec::CryptoVec;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver};
-use log::debug;
 
 use crate::{ChannelId, ChannelOpenFailure, ChannelStream, Error, Pty, Sig};
 

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -22,9 +22,9 @@ use std::num::Wrapping;
 use aes::{Aes128, Aes192, Aes256};
 use byteorder::{BigEndian, ByteOrder};
 use ctr::Ctr128BE;
+use log::debug;
 use once_cell::sync::Lazy;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use log::debug;
 
 use crate::mac::MacAlgorithm;
 use crate::sshbuffer::SSHBuffer;

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -55,7 +55,7 @@ impl Session {
                 // If we're not currently re-keying, but buf is a rekey request
                 let kexinit = if let Some(Kex::Init(kexinit)) = enc.rekey.take() {
                     Some(kexinit)
-                } else if let Some(exchange) = std::mem::replace(&mut enc.exchange, None) {
+                } else if let Some(exchange) = enc.exchange.take() {
                     Some(KexInit::received_rekey(
                         exchange,
                         negotiation::Client::read_kex(buf, &self.common.config.as_ref().preferred)?,

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -1041,7 +1041,7 @@ impl Session {
             )? {
                 info!("Re-exchanging keys");
                 if enc.rekey.is_none() {
-                    if let Some(exchange) = std::mem::replace(&mut enc.exchange, None) {
+                    if let Some(exchange) = enc.exchange.take() {
                         let mut kexinit = KexInit::initiate_rekey(exchange, &enc.session_id);
                         kexinit.client_write(
                             self.common.config.as_ref(),

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -1,6 +1,6 @@
+use log::error;
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::Encoding;
-use log::error;
 
 use crate::client::Session;
 use crate::session::EncryptedState;
@@ -81,7 +81,7 @@ impl Session {
 
     pub fn channel_open_direct_streamlocal(
         &mut self,
-        socket_path: &str
+        socket_path: &str,
     ) -> Result<ChannelId, crate::Error> {
         self.channel_open_generic(b"direct-streamlocal@openssh.com", |write| {
             write.extend_ssh_string(socket_path.as_bytes());

--- a/russh/src/kex/curve25519.rs
+++ b/russh/src/kex/curve25519.rs
@@ -103,9 +103,7 @@ impl KexAlgorithm for Curve25519Kex {
     }
 
     fn compute_shared_secret(&mut self, remote_pubkey_: &[u8]) -> Result<(), crate::Error> {
-        let local_secret =
-            std::mem::replace(&mut self.local_secret, None).ok_or(crate::Error::KexInit)?;
-
+        let local_secret = self.local_secret.take().ok_or(crate::Error::KexInit)?;
         let mut remote_pubkey = MontgomeryPoint([0; 32]);
         remote_pubkey.0.clone_from_slice(remote_pubkey_);
         let shared = local_secret * remote_pubkey;

--- a/russh/src/kex/dh/groups.rs
+++ b/russh/src/kex/dh/groups.rs
@@ -70,14 +70,8 @@ impl DH {
     pub fn generate_private_key(&mut self, is_server: bool) -> BigUint {
         let q = (&self.prime_num - &BigUint::from(1u8)) / &BigUint::from(2u8);
         let mut rng = rand::thread_rng();
-        self.private_key = rng.gen_biguint_range(
-            &if is_server {
-                1u8.into()
-            } else {
-                2u8.into()
-            },
-            &q,
-        );
+        self.private_key =
+            rng.gen_biguint_range(&if is_server { 1u8.into() } else { 2u8.into() }, &q);
         self.private_key.clone()
     }
 

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -96,9 +96,9 @@
 
 use std::fmt::{Debug, Display, Formatter};
 
-use thiserror::Error;
 use parsing::ChannelOpenConfirmation;
 pub use russh_cryptovec::CryptoVec;
+use thiserror::Error;
 
 mod auth;
 
@@ -904,7 +904,7 @@ mod test_channels {
                             ChannelMsg::Data { data } => {
                                 channel.data(&data[..]).await.unwrap();
                                 channel.close().await.unwrap();
-                                break
+                                break;
                             }
                             _ => {}
                         }

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -14,8 +14,8 @@
 //
 use std::str::from_utf8;
 
-use rand::RngCore;
 use log::debug;
+use rand::RngCore;
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::{Encoding, Reader};
 use russh_keys::key;

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -47,7 +47,7 @@ impl Session {
         // Either this packet is a KEXINIT, in which case we start a key re-exchange.
 
         #[allow(clippy::unwrap_used)]
-        let mut enc = self.common.encrypted.as_mut().unwrap();
+        let enc = self.common.encrypted.as_mut().unwrap();
         if buf.first() == Some(&msg::KEXINIT) {
             debug!("Received rekeying request");
             // If we're not currently rekeying, but `buf` is a rekey request
@@ -143,7 +143,7 @@ impl Session {
         };
 
         #[allow(clippy::unwrap_used)]
-        let mut enc = self.common.encrypted.as_mut().unwrap();
+        let enc = self.common.encrypted.as_mut().unwrap();
         // If we've successfully read a packet.
         match enc.state {
             EncryptedState::WaitingAuthServiceRequest {

--- a/russh/src/server/kex.rs
+++ b/russh/src/server/kex.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
-use russh_keys::encoding::{Encoding, Reader};
 use log::debug;
+use russh_keys::encoding::{Encoding, Reader};
 
 use super::*;
 use crate::cipher::SealingKey;

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -116,9 +116,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use log::error;
 use async_trait::async_trait;
 use futures::future::Future;
+use log::error;
 use russh_keys::key;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, ToSocketAddrs};

--- a/russh/src/ssh_read.rs
+++ b/russh/src/ssh_read.rs
@@ -1,9 +1,9 @@
 use std::pin::Pin;
 
 use futures::task::*;
+use log::debug;
 use russh_cryptovec::CryptoVec;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
-use log::debug;
 
 use crate::Error;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.70.0"


### PR DESCRIPTION
Hi again ☺️ I added a client part to `russh-sftp` for interacting with the protocol at any level, including high-level no worse than most crates. Please add an example, but I saw that this causes errors because your crate uses an outdated toolchain `1.65.0`, although a stable `1.70.0` has already been released which adds a lot of new things, if this does not cause problems for you, update it.