### PR TITLE
Followup for PR #181

### DIFF
--- a/russh/src/channels/channel_stream.rs
+++ b/russh/src/channels/channel_stream.rs
@@ -21,7 +21,7 @@ impl<S> ChannelStream<S>
 where
     S: From<(ChannelId, ChannelMsg)>,
 {
-    pub fn new(tx: ChannelTx<S>, rx: ChannelRx<'static, S>) -> Self {
+    pub(super) fn new(tx: ChannelTx<S>, rx: ChannelRx<'static, S>) -> Self {
         Self { tx, rx }
     }
 }

--- a/russh/src/channels/channel_stream.rs
+++ b/russh/src/channels/channel_stream.rs
@@ -9,6 +9,7 @@ use super::{
     ChannelId, ChannelMsg,
 };
 
+/// AsyncRead/AsyncWrite wrapper for SSH Channels
 pub struct ChannelStream<S>
 where
     S: From<(ChannelId, ChannelMsg)> + 'static,


### PR DESCRIPTION
This is a followup of #181 as asked by @Eugeny [here](https://github.com/warp-tech/russh/pull/181#issuecomment-1731527294), I took the liberty to suggest hiding `ChannelRx` & `ChannelTx` altogether with the `impl` syntax, as I though this was a better design, but is totally discuss-able :)