### PR TITLE
Make winapi dep windows only

### DIFF
--- a/cryptovec/Cargo.toml
+++ b/cryptovec/Cargo.toml
@@ -11,4 +11,6 @@ version = "0.7.0"
 
 [dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
 winapi = {version = "0.3", features = ["basetsd", "minwindef", "memoryapi"]}


### PR DESCRIPTION
This PR improves build time and disk usage by avoiding downloading the source for the winapi crate when not on windows.