### PR TITLE
Add client-sent keepalives

### DIFF
--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -776,6 +776,7 @@ impl Session {
         while !self.common.disconnected {
             tokio::select! {
                 () = &mut time_for_keepalive => {
+                    time_for_keepalive.as_mut().reset(self.common.config.keepalive_deadline());
                     self.send_keepalive(true);
                 }
                 r = &mut reading => {

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -288,6 +288,16 @@ impl Session {
         }
     }
 
+    pub fn send_keepalive(&mut self, want_reply: bool) {
+        if let Some(ref mut enc) = self.common.encrypted {
+            push_packet!(enc.write, {
+                enc.write.push(msg::GLOBAL_REQUEST);
+                enc.write.extend_ssh_string(b"keepalive@libssh2.org");
+                enc.write.push(want_reply as u8);
+            });
+        }
+    }
+
     pub fn data(&mut self, channel: ChannelId, data: CryptoVec) {
         if let Some(ref mut enc) = self.common.encrypted {
             enc.data(channel, data)


### PR DESCRIPTION
This is analogous to OpenSSH's `ServerAliveInterval` option and is of similar purpose. When the crate user is executing a command that will run for some time without producing output or expecting any input, it becomes difficult to distinguish between "the server has nothing to send" and "the connection to the server has been severed". A periodic keepalive puts an upper bound on how long an unexpected disconnection will go unnoticed in the absence of data traffic.

