### PR TITLE
Support hashed hostnames in known_hosts file

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -52,6 +52,7 @@ rand = "0.7"
 rand_core = { version = "0.6.4", features = ["std"] }
 russh-cryptovec = { version = "0.7.0", path = "../cryptovec" }
 serde = { version = "1.0", features = ["derive"] }
+sha1 = "0.10"
 sha2 = "0.10"
 thiserror = "1.0"
 tokio = { version = "1.17.0", features = [


### PR DESCRIPTION
OpenSSH supports hashed hostnames in the known_hosts file (`|1|...`). To improve interoperability, this PR extends this implementation to support such entries as well.