### PR TITLE
Fix handling of key constraints

### DIFF
--- a/russh-keys/src/agent/msg.rs
+++ b/russh-keys/src/agent/msg.rs
@@ -19,4 +19,5 @@ pub const EXTENSION: u8 = 27;
 
 pub const CONSTRAIN_LIFETIME: u8 = 1;
 pub const CONSTRAIN_CONFIRM: u8 = 2;
-pub const CONSTRAIN_EXTENSION: u8 = 3;
+// pub const CONSTRAIN_MAXSIGN: u8 = 3;
+pub const CONSTRAIN_EXTENSION: u8 = 255;

--- a/russh-keys/src/agent/server.rs
+++ b/russh-keys/src/agent/server.rs
@@ -325,10 +325,8 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
         let mut w = self.keys.0.write().or(Err(Error::AgentFailure))?;
         let now = SystemTime::now();
         if constrained {
-            let n = r.read_u32()?;
             let mut c = Vec::new();
-            for _ in 0..n {
-                let t = r.read_byte()?;
+            while let Ok(t) = r.read_byte() {
                 if t == msg::CONSTRAIN_LIFETIME {
                     let seconds = r.read_u32()?;
                     c.push(Constraint::KeyLifetime { seconds });
@@ -353,7 +351,7 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
                     return Ok(false);
                 }
             }
-            w.insert(blob, (Arc::new(key), now, Vec::new()));
+            w.insert(blob, (Arc::new(key), now, c));
         } else {
             w.insert(blob, (Arc::new(key), now, Vec::new()));
         }


### PR DESCRIPTION
I tested the ssh-agent client against OpenSSH and found some differences in the encoding of key constraints. This PR ensures both implementations are interoperable. In addition, the russh ssh-agent will actually store key constraints (it didn't until now). The client will check the response to report back any errors.