### PR TITLE
Run rustfmt in check mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
       run: rustup component add rustfmt
 
     - name: rustfmt
-      run: cargo fmt
+      run: cargo fmt --check
 
   Clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pass `--check` to rustfmt to ensure the step will fail if any file needs to be formatted.