### PR TITLE
Support for NIST P-256 public keys

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -47,6 +47,7 @@ md5 = "0.7"
 num-bigint = "0.4"
 num-integer = "0.1"
 openssl = { version = "0.10", optional = true }
+p256 = "0.13"
 pbkdf2 = "0.11"
 rand = "0.7"
 rand_core = { version = "0.6.4", features = ["std"] }

--- a/russh/src/key.rs
+++ b/russh/src/key.rs
@@ -15,6 +15,7 @@
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::*;
 use russh_keys::key::*;
+use russh_keys::PublicKeyBase64;
 
 #[doc(hidden)]
 pub trait PubKey {
@@ -28,6 +29,9 @@ impl PubKey for PublicKey {
                 buffer.push_u32_be((ED25519.0.len() + public.as_bytes().len() + 8) as u32);
                 buffer.extend_ssh_string(ED25519.0.as_bytes());
                 buffer.extend_ssh_string(public.as_bytes());
+            }
+            PublicKey::P256(_) => {
+                buffer.extend_ssh_string(&self.public_key_bytes());
             }
             #[cfg(feature = "openssl")]
             PublicKey::RSA { ref key, .. } => {

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -76,19 +76,16 @@ const HMAC_ORDER: &[mac::Name] = &[
 ];
 
 impl Preferred {
-    #[cfg(feature = "openssl")]
     pub const DEFAULT: Preferred = Preferred {
         kex: SAFE_KEX_ORDER,
-        key: &[key::ED25519, key::RSA_SHA2_256, key::RSA_SHA2_512],
-        cipher: CIPHER_ORDER,
-        mac: HMAC_ORDER,
-        compression: &["none", "zlib", "zlib@openssh.com"],
-    };
-
-    #[cfg(not(feature = "openssl"))]
-    pub const DEFAULT: Preferred = Preferred {
-        kex: SAFE_KEX_ORDER,
-        key: &[key::ED25519],
+        key: &[
+            key::ED25519,
+            key::ECDSA_SHA2_NISTP256,
+            #[cfg(feature = "openssl")]
+            key::RSA_SHA2_256,
+            #[cfg(feature = "openssl")]
+            key::RSA_SHA2_512,
+        ],
         cipher: CIPHER_ORDER,
         mac: HMAC_ORDER,
         compression: &["none", "zlib", "zlib@openssh.com"],
@@ -96,7 +93,7 @@ impl Preferred {
 
     pub const COMPRESSED: Preferred = Preferred {
         kex: SAFE_KEX_ORDER,
-        key: &[key::ED25519, key::RSA_SHA2_256, key::RSA_SHA2_512],
+        key: Preferred::DEFAULT.key,
         cipher: CIPHER_ORDER,
         mac: HMAC_ORDER,
         compression: &["zlib", "zlib@openssh.com", "none"],
@@ -121,15 +118,15 @@ impl Named for () {
     }
 }
 
-#[cfg(not(feature = "openssl"))]
-use russh_keys::key::ED25519;
 #[cfg(feature = "openssl")]
-use russh_keys::key::{ED25519, SSH_RSA};
+use russh_keys::key::SSH_RSA;
+use russh_keys::key::{ECDSA_SHA2_NISTP256, ED25519};
 
 impl Named for PublicKey {
     fn name(&self) -> &'static str {
         match self {
             PublicKey::Ed25519(_) => ED25519.0,
+            PublicKey::P256(_) => ECDSA_SHA2_NISTP256.0,
             #[cfg(feature = "openssl")]
             PublicKey::RSA { .. } => SSH_RSA.0,
         }


### PR DESCRIPTION
This PR implements support for `ecdsa-sha2-nistp256` public keys based on [`p256`](https://crates.io/crates/p256). 