### PR TITLE
Fix ChannelMsg::close docs

### DIFF
--- a/russh/src/channels/mod.rs
+++ b/russh/src/channels/mod.rs
@@ -32,6 +32,7 @@ pub enum ChannelMsg {
         ext: u32,
     },
     Eof,
+    Close,
     /// (client only)
     RequestPty {
         want_reply: bool,
@@ -109,8 +110,6 @@ pub enum ChannelMsg {
     Success,
     /// (server only)
     Failure,
-    /// (server only)
-    Close,
     OpenFailure(ChannelOpenFailure),
 }
 


### PR DESCRIPTION
As per the protocol specification: https://datatracker.ietf.org/doc/html/rfc4254#section-5.3
`SSH_MSG_CHANNEL_CLOSE` can be sent by the client as well as the server, so the `(server only)` comment is incorrect.