### PR TITLE
Improve #196 and #211

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "russh"
 readme = "../README.md"
 repository = "https://github.com/warp-tech/russh"
-version = "0.40.2"
+version = "0.41.0-beta.1"
 rust-version = "1.65"
 
 [features]

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -540,6 +540,7 @@ impl Session {
                 );
                 match req {
                     b"xon-xoff" => {
+                        self.activity = false;
                         r.read_byte().map_err(crate::Error::from)?; // should be 0.
                         let client_can_do = r.read_byte().map_err(crate::Error::from)? != 0;
                         if let Some(chan) = self.channels.get(&channel_num) {
@@ -586,6 +587,7 @@ impl Session {
                             .await
                     }
                     b"keepalive@openssh.com" => {
+                        self.activity = false;
                         let wants_reply = r.read_byte().map_err(crate::Error::from)?;
                         if wants_reply == 1 {
                             if let Some(ref mut enc) = self.common.encrypted {
@@ -605,6 +607,7 @@ impl Session {
                         Ok((client, self))
                     }
                     _ => {
+                        self.activity = false;
                         let wants_reply = r.read_byte().map_err(crate::Error::from)?;
                         if wants_reply == 1 {
                             if let Some(ref mut enc) = self.common.encrypted {
@@ -704,6 +707,7 @@ impl Session {
                         push_packet!(enc.write, enc.write.push(msg::REQUEST_FAILURE))
                     }
                 }
+                self.activity = false;
                 Ok((client, self))
             }
             Some(&msg::CHANNEL_SUCCESS) => {
@@ -816,7 +820,16 @@ impl Session {
                     Err(crate::Error::Inconsistent.into())
                 }
             }
+            Some(&msg::REQUEST_SUCCESS | &msg::REQUEST_FAILURE)
+                if self.server_alive_timeouts > 0 =>
+            {
+                self.activity = false;
+                // TODO what other things might need to happen in response to these two opcodes?
+                self.server_alive_timeouts = 0;
+                Ok((client, self))
+            }
             _ => {
+                self.activity = false;
                 info!("Unhandled packet: {:?}", buf);
                 Ok((client, self))
             }

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -105,8 +105,8 @@ use crate::session::{CommonSession, EncryptedState, Exchange, Kex, KexDhDone, Ke
 use crate::ssh_read::SshRead;
 use crate::sshbuffer::{SSHBuffer, SshId};
 use crate::{
-    auth, msg, negotiation, strict_kex_violation, ChannelId, ChannelOpenFailure,
-    Disconnect, Limits, Sig,
+    auth, msg, negotiation, strict_kex_violation, ChannelId, ChannelOpenFailure, Disconnect,
+    Limits, Sig,
 };
 
 mod encrypted;

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -128,8 +128,6 @@ pub struct Session {
     pending_len: u32,
     inbound_channel_sender: Sender<Msg>,
     inbound_channel_receiver: Receiver<Msg>,
-    server_alive_timeouts: usize,
-    activity: bool,
 }
 
 const STRICT_KEX_MSG_ORDER: &[u8] = &[msg::KEXINIT, msg::KEX_ECDH_REPLY, msg::NEWKEYS];
@@ -700,6 +698,8 @@ where
             disconnected: false,
             buffer: CryptoVec::new(),
             strict_kex: false,
+            alive_timeouts: 0,
+            received_data: false,
         },
         session_receiver,
         session_sender,
@@ -730,16 +730,6 @@ async fn start_reading<R: AsyncRead + Unpin>(
     Ok((n, stream_read, buffer, cipher))
 }
 
-fn future_or_pending<F: futures::Future, T>(
-    val: Option<T>,
-    f: impl FnOnce(T) -> F,
-) -> futures::future::Either<futures::future::Pending<<F as futures::Future>::Output>, F> {
-    val.map_or(
-        futures::future::Either::Left(futures::future::pending()),
-        |x| futures::future::Either::Right(f(x)),
-    )
-}
-
 impl Session {
     fn new(
         target_window_size: u32,
@@ -758,8 +748,6 @@ impl Session {
             channels: HashMap::new(),
             pending_reads: Vec::new(),
             pending_len: 0,
-            server_alive_timeouts: 0,
-            activity: false,
         }
     }
 
@@ -789,11 +777,11 @@ impl Session {
         std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
 
         let keepalive_timer =
-            future_or_pending(self.common.config.keepalive_interval, tokio::time::sleep);
+            crate::future_or_pending(self.common.config.keepalive_interval, tokio::time::sleep);
         pin!(keepalive_timer);
 
         let inactivity_timer =
-            future_or_pending(self.common.config.inactivity_timeout, tokio::time::sleep);
+            crate::future_or_pending(self.common.config.inactivity_timeout, tokio::time::sleep);
         pin!(inactivity_timer);
 
         let reading = start_reading(stream_read, buffer, opening_cipher);
@@ -801,20 +789,9 @@ impl Session {
 
         #[allow(clippy::panic)] // false positive in select! macro
         while !self.common.disconnected {
-            self.activity = false;
+            self.common.received_data = false;
+            let mut only_sent_keepalive = false;
             tokio::select! {
-                () = &mut keepalive_timer => {
-                    self.send_keepalive(true);
-                    if self.common.config.keepalive_max != 0 && self.server_alive_timeouts > self.common.config.keepalive_max {
-                        debug!("Timeout, server not responding to keepalives");
-                        break
-                    }
-                    self.server_alive_timeouts = self.server_alive_timeouts.saturating_add(1);
-                }
-                () = &mut inactivity_timer => {
-                    debug!("timeout");
-                    break
-                }
                 r = &mut reading => {
                     let (stream_read, mut buffer, mut opening_cipher) = match r {
                         Ok((_, stream_read, buffer, opening_cipher)) => (stream_read, buffer, opening_cipher),
@@ -846,7 +823,7 @@ impl Session {
                         if buf[0] == crate::msg::DISCONNECT {
                             break;
                         } else {
-                            self.activity = true;
+                            self.common.received_data = true;
                             let (h, s) = reply(self, handler, &mut encrypted_signal, &mut buffer.seqn, buf).await?;
                             handler = h;
                             self = s;
@@ -855,6 +832,19 @@ impl Session {
 
                     std::mem::swap(&mut opening_cipher, &mut self.common.cipher.remote_to_local);
                     reading.set(start_reading(stream_read, buffer, opening_cipher));
+                }
+                () = &mut keepalive_timer => {
+                    self.send_keepalive(true);
+                    only_sent_keepalive = true;
+                    if self.common.config.keepalive_max != 0 && self.common.alive_timeouts > self.common.config.keepalive_max {
+                        debug!("Timeout, server not responding to keepalives");
+                        break
+                    }
+                    self.common.alive_timeouts = self.common.alive_timeouts.saturating_add(1);
+                }
+                () = &mut inactivity_timer => {
+                    debug!("timeout");
+                    break
                 }
                 msg = self.receiver.recv(), if !self.is_rekeying() => {
                     match msg {
@@ -895,7 +885,6 @@ impl Session {
                     "writing to stream: {:?} bytes",
                     self.common.write_buffer.buffer.len()
                 );
-                self.activity = true;
                 stream_write
                     .write_all(&self.common.write_buffer.buffer)
                     .await
@@ -910,14 +899,15 @@ impl Session {
                 }
             }
 
-            if let (futures::future::Either::Right(ref mut sleep), Some(d)) = (
-                keepalive_timer.as_mut().as_pin_mut(),
-                self.common.config.keepalive_interval,
-            ) {
-                sleep.as_mut().reset(tokio::time::Instant::now() + d);
+            if self.common.received_data {
+                if let (futures::future::Either::Right(ref mut sleep), Some(d)) = (
+                    keepalive_timer.as_mut().as_pin_mut(),
+                    self.common.config.keepalive_interval,
+                ) {
+                    sleep.as_mut().reset(tokio::time::Instant::now() + d);
+                }
             }
-
-            if self.activity {
+            if !only_sent_keepalive {
                 if let (futures::future::Either::Right(ref mut sleep), Some(d)) = (
                     inactivity_timer.as_mut().as_pin_mut(),
                     self.common.config.inactivity_timeout,
@@ -1348,7 +1338,7 @@ pub struct Config {
     pub preferred: negotiation::Preferred,
     /// Time after which the connection is garbage-collected.
     pub inactivity_timeout: Option<std::time::Duration>,
-    /// If nothing is sent or received for this amount of time, send a keepalive message.
+    /// If nothing is received from the server for this amount of time, send a keepalive message.
     pub keepalive_interval: Option<std::time::Duration>,
     /// If this many keepalives have been sent without reply, close the connection.
     pub keepalive_max: usize,

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -292,7 +292,7 @@ impl Session {
         if let Some(ref mut enc) = self.common.encrypted {
             push_packet!(enc.write, {
                 enc.write.push(msg::GLOBAL_REQUEST);
-                enc.write.extend_ssh_string(b"keepalive@libssh2.org");
+                enc.write.extend_ssh_string(b"keepalive@openssh.org");
                 enc.write.push(want_reply as u8);
             });
         }

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -484,10 +484,12 @@ impl ChannelParams {
     }
 }
 
-pub(crate) async fn timeout(delay: Option<std::time::Duration>) {
-    if let Some(delay) = delay {
-        tokio::time::sleep(delay).await
-    } else {
-        futures::future::pending().await
-    };
+pub(crate) fn future_or_pending<F: futures::Future, T>(
+    val: Option<T>,
+    f: impl FnOnce(T) -> F,
+) -> futures::future::Either<futures::future::Pending<<F as futures::Future>::Output>, F> {
+    val.map_or(
+        futures::future::Either::Left(futures::future::pending()),
+        |x| futures::future::Either::Right(f(x)),
+    )
 }

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -966,6 +966,7 @@ impl Session {
                         handler.signal(channel_num, signal, self).await
                     }
                     x => {
+                        self.common.received_data = false;
                         warn!("unknown channel request {}", String::from_utf8_lossy(x));
                         self.channel_failure(channel_num);
                         Ok((handler, self))
@@ -1019,6 +1020,7 @@ impl Session {
                         Ok((h, s))
                     }
                     _ => {
+                        self.common.received_data = false;
                         if let Some(ref mut enc) = self.common.encrypted {
                             push_packet!(enc.write, {
                                 enc.write.push(msg::REQUEST_FAILURE);
@@ -1058,6 +1060,7 @@ impl Session {
                 Ok((handler, self))
             }
             m => {
+                self.common.received_data = false;
                 debug!("unknown message received: {:?}", m);
                 Ok((handler, self))
             }

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -169,6 +169,10 @@ pub struct Config {
     pub max_auth_attempts: usize,
     /// Time after which the connection is garbage-collected.
     pub inactivity_timeout: Option<std::time::Duration>,
+    /// If nothing is received from the client for this amount of time, send a keepalive message.
+    pub keepalive_interval: Option<std::time::Duration>,
+    /// If this many keepalives have been sent without reply, close the connection.
+    pub keepalive_max: usize,
 }
 
 impl Default for Config {
@@ -191,6 +195,8 @@ impl Default for Config {
             preferred: Default::default(),
             max_auth_attempts: 10,
             inactivity_timeout: Some(std::time::Duration::from_secs(600)),
+            keepalive_interval: None,
+            keepalive_max: 3,
         }
     }
 }
@@ -807,6 +813,8 @@ async fn read_ssh_id<R: AsyncRead + Unpin>(
         disconnected: false,
         buffer: CryptoVec::new(),
         strict_kex: false,
+        alive_timeouts: 0,
+        received_data: false,
     })
 }
 

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -64,6 +64,8 @@ pub(crate) struct CommonSession<Config> {
     pub disconnected: bool,
     pub buffer: CryptoVec,
     pub strict_kex: bool,
+    pub alive_timeouts: usize,
+    pub received_data: bool,
 }
 
 impl<C> CommonSession<C> {


### PR DESCRIPTION
* Rewrite these two features using disjunctive futures in order to cleanly make the timers optional.
  This works because of https://docs.rs/futures/latest/futures/future/enum.Either.html#impl-Future-for-Either%3CA,+B%3E.
  It theoretically works best because reusing the same futures means Tokio has to do less bookkeeping. Every non-diverging exit from the `select!` will reset the keepalive timer, and will also reset the inactivity timer if any nontrivial I/O happened.
* Add an analogue of OpenSSH's `ServerAliveCountMax`.
  A counter is persisted on the `Session`; incremented when a keepalive is sent; and reset when a REQUEST_SUCCESS or REQUEST_FAILURE is received (presumably in reply to a keepalive). If it passes a configurable threshold, the connection is cut.
* Mutate the `Session` to pass information back to the main bg loop from the plaintext packet reader, so that only nontrivial data transfer will reset the inactivity timer. (And so that `ServerAliveCountMax` will be judged correctly.)