### PR TITLE
Avert the race between sending data and sending EOF

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -738,6 +738,8 @@ impl Session {
                         confirmed: true,
                         wants_reply: false,
                         pending_data: std::collections::VecDeque::new(),
+                        pending_eof: false,
+                        pending_close: false,
                     };
 
                     let confirm = || {

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -473,6 +473,8 @@ pub(crate) struct ChannelParams {
     pub confirmed: bool,
     wants_reply: bool,
     pending_data: std::collections::VecDeque<(CryptoVec, Option<u32>, usize)>,
+    pending_eof: bool,
+    pending_close: bool,
 }
 
 impl ChannelParams {

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -1090,6 +1090,8 @@ impl Session {
             confirmed: true,
             wants_reply: false,
             pending_data: std::collections::VecDeque::new(),
+            pending_eof: false,
+            pending_close: false,
         };
 
         let (channel, reference) = Channel::new(

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -68,8 +68,14 @@ pub(crate) struct CommonSession<Config> {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ChannelFlushResult {
-    Incomplete { wrote: usize, },
-    Complete { wrote: usize, pending_eof: bool, pending_close: bool, }
+    Incomplete {
+        wrote: usize,
+    },
+    Complete {
+        wrote: usize,
+        pending_eof: bool,
+        pending_close: bool,
+    },
 }
 impl ChannelFlushResult {
     pub(crate) fn wrote(&self) -> usize {
@@ -79,7 +85,11 @@ impl ChannelFlushResult {
         }
     }
     pub(crate) fn complete(wrote: usize, channel: &ChannelParams) -> Self {
-        ChannelFlushResult::Complete { wrote, pending_eof: channel.pending_eof, pending_close: channel.pending_close }
+        ChannelFlushResult::Complete {
+            wrote,
+            pending_eof: channel.pending_eof,
+            pending_close: channel.pending_close,
+        }
     }
 }
 
@@ -233,14 +243,21 @@ impl Encrypted {
             pending_size += size;
             if from + size < buf.len() {
                 channel.pending_data.push_front((buf, a, from + size));
-                return ChannelFlushResult::Incomplete { wrote: pending_size };
+                return ChannelFlushResult::Incomplete {
+                    wrote: pending_size,
+                };
             }
         }
         ChannelFlushResult::complete(pending_size, channel)
     }
 
     fn handle_flushed_channel(&mut self, channel: ChannelId, flush_result: ChannelFlushResult) {
-        if let ChannelFlushResult::Complete { wrote: _, pending_eof, pending_close } = flush_result {
+        if let ChannelFlushResult::Complete {
+            wrote: _,
+            pending_eof,
+            pending_close,
+        } = flush_result
+        {
             if pending_eof {
                 self.eof(channel);
             }
@@ -272,7 +289,9 @@ impl Encrypted {
     }
 
     fn has_pending_data_mut(&mut self, channel: ChannelId) -> Option<&mut ChannelParams> {
-        self.channels.get_mut(&channel).filter(|c| !c.pending_data.is_empty())
+        self.channels
+            .get_mut(&channel)
+            .filter(|c| !c.pending_data.is_empty())
     }
 
     pub fn has_pending_data(&self, channel: ChannelId) -> bool {


### PR DESCRIPTION
This fixes #213. Also, while verifying as such, I noticed that an unrelated modification to client_exec_simple was required for correct operation, and have included it here. Namely: the receiving event-loop should not terminate early upon receiving the exit status, since SSH servers can and will send data after sending the exit status.

Also, I did something similar for the `close` operation.

Also, my initial attempt at this involved generalizing the pending_data queue so that it could contain EOF packets. That doesn't work at all, but I left in-place a refactor which should stop outgoing extended data from being transformed into regular data when placed into the pending deque.

In theory, an extra flag to restore the previous behavior might be desirable in case the previous behavior happens to be desirable; but that would be a not-strictly-necessary breaking change to the public API.

I see one downside. Consider the usecase - albeit very odd imho - where a channel has multiple owners that all constantly send a large volume of data (such that the pending deque does not empty itself as long as the sending continues) and do not cooperate among themselves as to when the channel is done being sent data. In this scenario, the status quo means that the first owner who wants an EOF will indeed cause the EOF to be sent, promptly but imprecisely. Whereas with this PR's change, the EOF might not be sent until the owners unanimously agree to cease sending data. The only way to tolerate this that I can fathom, would be to add some way to notify the user that a given channel's pending data buffer has been completely flushed - owners of singly-owned channels who have scheduled all outgoing data could await that message before sending EOF, and owners of multiply-owned channels would remain free to send EOF as soon as they please.