### PR TITLE
Support NIST P-521 public keys

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -25,7 +25,7 @@ keywords = ["ssh"]
 license = "Apache-2.0"
 name = "russh-keys"
 repository = "https://github.com/warp-tech/russh"
-version = "0.40.1"
+version = "0.41.0-beta.1"
 rust-version = "1.65"
 
 [dependencies]

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -64,6 +64,7 @@ tokio = { version = "1.17.0", features = [
 ] }
 tokio-stream = { version = "0.1", features = ["net"] }
 yasna = { version = "0.5.0", features = ["bit-vec", "num-bigint"] }
+p521 = "0.13.3"
 
 [features]
 vendored-openssl = ["openssl", "openssl/vendored"]

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -49,6 +49,7 @@ num-bigint = "0.4"
 num-integer = "0.1"
 openssl = { version = "0.10", optional = true }
 p256 = "0.13"
+p521 = "0.13"
 pbkdf2 = "0.11"
 rand = "0.7"
 rand_core = { version = "0.6.4", features = ["std"] }
@@ -65,7 +66,6 @@ tokio = { version = "1.17.0", features = [
 ] }
 tokio-stream = { version = "0.1", features = ["net"] }
 yasna = { version = "0.5.0", features = ["bit-vec", "num-bigint"] }
-p521 = "0.13.3"
 
 [features]
 vendored-openssl = ["openssl", "openssl/vendored"]

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -614,6 +614,14 @@ QR+u0AypRPmzHnOPAAAAEXJvb3RAMTQwOTExNTQ5NDBkAQ==
     }
 
     #[test]
+    fn test_parse_p521_public_key() {
+        env_logger::try_init().unwrap_or(());
+        let key = "AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAAQepXEpOrzlX22r4E5zEHjhHWeZUe//zaevTanOWRBnnaCGWJFGCdjeAbNOuAmLtXc+HZdJTCZGREeSLSrpJa71QDCgZl0N7DkDUanCpHZJe/DCK6qwtHYbEMn28iLMlGCOrCIa060EyJHbp1xcJx4I1SKj/f/fm3DhhID/do6zyf8Cg==";
+
+        parse_public_key_base64(key).unwrap();
+    }
+
+    #[test]
     #[cfg(feature = "openssl")]
     fn test_srhb() {
         env_logger::try_init().unwrap_or(());

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -102,8 +102,8 @@ pub enum Error {
     #[error("Invalid Ed25519 key data")]
     Ed25519KeyError(#[from] ed25519_dalek::SignatureError),
     /// The type of the key is unsupported
-    #[error("Invalid NIST-P256 key data")]
-    P256KeyError(#[from] p256::elliptic_curve::Error),
+    #[error("Invalid ECDSA key data")]
+    EcdsaKeyError(#[from] p256::elliptic_curve::Error),
     /// The key is encrypted (should supply a password?)
     #[error("The key is encrypted")]
     KeyIsEncrypted,
@@ -240,6 +240,12 @@ impl PublicKeyBase64 for key::PublicKey {
                 use encoding::Encoding;
                 s.extend_ssh_string(b"ecdsa-sha2-nistp256");
                 s.extend_ssh_string(b"nistp256");
+                s.extend_ssh_string(&publickey.to_sec1_bytes());
+            }
+            key::PublicKey::P521(ref publickey) => {
+                use encoding::Encoding;
+                s.extend_ssh_string(b"ecdsa-sha2-nistp521");
+                s.extend_ssh_string(b"nistp521");
                 s.extend_ssh_string(&publickey.to_sec1_bytes());
             }
         }

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "russh"
 readme = "../README.md"
 repository = "https://github.com/warp-tech/russh"
-version = "0.41.0-beta.1"
+version = "0.41.0-beta.2"
 rust-version = "1.65"
 
 [features]
@@ -37,7 +37,7 @@ once_cell = "1.13"
 openssl = { version = "0.10", optional = true }
 rand = "0.8"
 russh-cryptovec = { version = "0.7.0", path = "../cryptovec" }
-russh-keys = { version = "0.40", path = "../russh-keys" }
+russh-keys = { version = "0.41.0-beta.1", path = "../russh-keys" }
 sha1 = "0.10"
 sha2 = "0.10"
 hex-literal = "0.4"

--- a/russh/src/key.rs
+++ b/russh/src/key.rs
@@ -30,7 +30,7 @@ impl PubKey for PublicKey {
                 buffer.extend_ssh_string(ED25519.0.as_bytes());
                 buffer.extend_ssh_string(public.as_bytes());
             }
-            PublicKey::P256(_) => {
+            PublicKey::P256(_) | PublicKey::P521(_) => {
                 buffer.extend_ssh_string(&self.public_key_bytes());
             }
             #[cfg(feature = "openssl")]

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -81,6 +81,7 @@ impl Preferred {
         key: &[
             key::ED25519,
             key::ECDSA_SHA2_NISTP256,
+            key::ECDSA_SHA2_NISTP521,
             #[cfg(feature = "openssl")]
             key::RSA_SHA2_256,
             #[cfg(feature = "openssl")]
@@ -120,13 +121,14 @@ impl Named for () {
 
 #[cfg(feature = "openssl")]
 use russh_keys::key::SSH_RSA;
-use russh_keys::key::{ECDSA_SHA2_NISTP256, ED25519};
+use russh_keys::key::{ECDSA_SHA2_NISTP256, ECDSA_SHA2_NISTP521, ED25519};
 
 impl Named for PublicKey {
     fn name(&self) -> &'static str {
         match self {
             PublicKey::Ed25519(_) => ED25519.0,
             PublicKey::P256(_) => ECDSA_SHA2_NISTP256.0,
+            PublicKey::P521(_) => ECDSA_SHA2_NISTP521.0,
             #[cfg(feature = "openssl")]
             PublicKey::RSA { .. } => SSH_RSA.0,
         }


### PR DESCRIPTION
This PR adds support for the `ecdsa-sha2-nistp521` algorithm. The code is far from perfect and could use some polishing.