### PR TITLE
server/encrypted.rs: respect `proceed_with_methods` in "none" and "password" authentication methods

### DIFF
--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -300,7 +300,14 @@ impl Encrypted {
                     self.state = EncryptedState::InitCompression;
                 } else {
                     auth_user.clear();
-                    auth_request.methods -= MethodSet::PASSWORD;
+                    if let Auth::Reject {
+                        proceed_with_methods: Some(proceed_with_methods),
+                    } = auth
+                    {
+                        auth_request.methods = proceed_with_methods;
+                    } else {
+                        auth_request.methods -= MethodSet::PASSWORD;
+                    }
                     auth_request.partial_success = false;
                     reject_auth_request(until, &mut self.write, auth_request).await;
                 }
@@ -326,7 +333,14 @@ impl Encrypted {
                     self.state = EncryptedState::InitCompression;
                 } else {
                     auth_user.clear();
-                    auth_request.methods -= MethodSet::NONE;
+                    if let Auth::Reject {
+                        proceed_with_methods: Some(proceed_with_methods),
+                    } = auth
+                    {
+                        auth_request.methods = proceed_with_methods;
+                    } else {
+                        auth_request.methods -= MethodSet::NONE;
+                    }
                     auth_request.partial_success = false;
                     reject_auth_request(until, &mut self.write, auth_request).await;
                 }


### PR DESCRIPTION
Currently, [`proceed_with_methods`](https://github.com/warp-tech/russh/blob/2ce133d794ba5c674b67f165db9d39b69bc3948c/russh/src/server/mod.rs#L231) on the `Auth::Reject` enum is only respected in public-key [[source](https://github.com/warp-tech/russh/blob/2ce133d794ba5c674b67f165db9d39b69bc3948c/russh/src/server/encrypted.rs#L453-L458), [source](https://github.com/warp-tech/russh/blob/2ce133d794ba5c674b67f165db9d39b69bc3948c/russh/src/server/encrypted.rs#L497-L502)] and keyboard-interactive requests [[source](https://github.com/warp-tech/russh/blob/2ce133d794ba5c674b67f165db9d39b69bc3948c/russh/src/server/encrypted.rs#L586-L588)]. This PR updates [`server_read_auth_request`](https://github.com/warp-tech/russh/blob/2ce133d794ba5c674b67f165db9d39b69bc3948c/russh/src/server/encrypted.rs#L263C14-L263C38) to respect `proceed_with_methods` on all auth request types.