### PR TITLE
Fix https://github.com/warp-tech/russh/issues/232

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -605,7 +605,6 @@ impl Session {
                         Ok((client, self))
                     }
                     _ => {
-                        self.common.received_data = false;
                         let wants_reply = r.read_byte().map_err(crate::Error::from)?;
                         if wants_reply == 1 {
                             if let Some(ref mut enc) = self.common.encrypted {
@@ -705,7 +704,6 @@ impl Session {
                         push_packet!(enc.write, enc.write.push(msg::REQUEST_FAILURE))
                     }
                 }
-                self.common.received_data = false;
                 Ok((client, self))
             }
             Some(&msg::CHANNEL_SUCCESS) => {
@@ -828,7 +826,6 @@ impl Session {
                 Ok((client, self))
             }
             _ => {
-                self.common.received_data = false;
                 info!("Unhandled packet: {:?}", buf);
                 Ok((client, self))
             }

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -899,6 +899,14 @@ impl Session {
                 }
             }
 
+            if self.common.received_data {
+                // Reset the number of failed keepalive attempts. We don't
+                // bother detecting keepalive response messages specifically
+                // (OpenSSH_9.6p1 responds with REQUEST_FAILURE aka 82). Instead
+                // we assume that the server is still alive if we receive any
+                // data from it.
+                self.common.alive_timeouts = 0;
+            }
             if self.common.received_data || sent_keepalive {
                 if let (futures::future::Either::Right(ref mut sleep), Some(d)) = (
                     keepalive_timer.as_mut().as_pin_mut(),

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -980,7 +980,6 @@ impl Session {
                         handler.signal(channel_num, signal, self).await
                     }
                     x => {
-                        self.common.received_data = false;
                         warn!("unknown channel request {}", String::from_utf8_lossy(x));
                         self.channel_failure(channel_num);
                         Ok((handler, self))
@@ -1034,7 +1033,6 @@ impl Session {
                         Ok((h, s))
                     }
                     _ => {
-                        self.common.received_data = false;
                         if let Some(ref mut enc) = self.common.encrypted {
                             push_packet!(enc.write, {
                                 enc.write.push(msg::REQUEST_FAILURE);
@@ -1074,7 +1072,6 @@ impl Session {
                 Ok((handler, self))
             }
             m => {
-                self.common.received_data = false;
                 debug!("unknown message received: {:?}", m);
                 Ok((handler, self))
             }

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -500,6 +500,14 @@ impl Session {
                 .map_err(crate::Error::from)?;
             self.common.write_buffer.buffer.clear();
 
+            if self.common.received_data {
+                // Reset the number of failed keepalive attempts. We don't
+                // bother detecting keepalive response messages specifically
+                // (OpenSSH_9.6p1 responds with REQUEST_FAILURE aka 82). Instead
+                // we assume that the client is still alive if we receive any
+                // data from it.
+                self.common.alive_timeouts = 0;
+            }
             if self.common.received_data || sent_keepalive {
                 if let (futures::future::Either::Right(ref mut sleep), Some(d)) = (
                     keepalive_timer.as_mut().as_pin_mut(),


### PR DESCRIPTION
Upon debugging, I discovered that `alive_timeouts` is not currently ever reset to 0 anywhere. The diff in `server/session.rs` remedies this, reseting `alive_timeouts` to 0 any time we receive data from the client.

Unfortunately, there was additionally the issue that `self.common.received_data` was not in fact a reliable indicator of whether or not we had actually received data from the client. This turned out to be due to some logic in `server/encrypted.rs` that overrode the assignment [here](https://github.com/warp-tech/russh/blob/c7f6c5b867fd063c383a7e07acd311ffce0d1c80/russh/src/server/session.rs#L403) if the message was not one of the expected format. I have removed this logic in `server/encrypted.rs`.

`self.common.received_data` is not documented or defined AFAIK. Looking through the code, I concluded that `server/encrypted.rs` was in the wrong and should be modified, but some scrutiny on this decision may be warranted. In any case, this fixes https://github.com/warp-tech/russh/issues/232.