### PR TITLE
Global request response handling

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -25,7 +25,7 @@ use crate::client::{Handler, Msg, Prompt, Reply, Session};
 use crate::key::PubKey;
 use crate::negotiation::{Named, Select};
 use crate::parsing::{ChannelOpenConfirmation, ChannelType, OpenChannelMessage};
-use crate::session::{Encrypted, EncryptedState, Kex, KexInit};
+use crate::session::{Encrypted, EncryptedState, GlobalRequestResponse, Kex, KexInit};
 use crate::{
     auth, msg, negotiation, strict_kex_violation, Channel, ChannelId, ChannelMsg,
     ChannelOpenFailure, ChannelParams, Sig,
@@ -817,18 +817,51 @@ impl Session {
             }
             Some(&msg::REQUEST_SUCCESS) => {
                 trace!("Global Request Success");
+                match self.open_global_requests.pop_front() {
+                    Some(GlobalRequestResponse::Keepalive) => {
+                        // ignore keepalives
+                    }
+                    Some(GlobalRequestResponse::TcpIpForward(return_channel)) => {
+                        let result = if buf.len() == 1 {
+                            // If a specific port was requested, the reply has no data
+                            Some(0)
+                        } else {
+                            let mut r = buf.reader(1);
+                            match r.read_u32() {
+                                Ok(port) => Some(port),
+                                Err(e) => {
+                                    error!("Error parsing port for TcpIpForward request: {e:?}");
+                                    None
+                                }
+                            }
+                        };
+                        let _ = return_channel.send(result);
+                    }
+                    Some(GlobalRequestResponse::CancelTcpIpForward(return_channel)) => {
+                        let _ = return_channel.send(true);
+                    }
+                    None => {
+                        error!("Received global request failure for unknown request!")
+                    }
+                }
                 Ok(())
             }
             Some(&msg::REQUEST_FAILURE) => {
-                // Right now, the only global request we send with a request for reply is keepalive,
-                // which just needs to be ignored.
-                // If there are other global requests with reply implemented,
-                // we'll need to build infrastructure to filter the expected request failures from the keepalive
-                // The following works as long as only a single keepalive request was sent before a reply:
-                // `if self.common.alive_timeouts > 0`
-                // since any data received will reset alive_timeouts back to zero,
-                // even if multiple keepalives will be processed due to TCP delivering all of them after connectivity was restored
-                trace!("Global Request Failure");
+                trace!("global request failure");
+                match self.open_global_requests.pop_front() {
+                    Some(GlobalRequestResponse::Keepalive) => {
+                        // ignore keepalives
+                    }
+                    Some(GlobalRequestResponse::TcpIpForward(return_channel)) => {
+                        let _ = return_channel.send(None);
+                    }
+                    Some(GlobalRequestResponse::CancelTcpIpForward(return_channel)) => {
+                        let _ = return_channel.send(false);
+                    }
+                    None => {
+                        error!("Received global request failure for unknown request!")
+                    }
+                }
                 Ok(())
             }
             m => {

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -292,7 +292,7 @@ impl Session {
         if let Some(ref mut enc) = self.common.encrypted {
             push_packet!(enc.write, {
                 enc.write.push(msg::GLOBAL_REQUEST);
-                enc.write.extend_ssh_string(b"keepalive@openssh.org");
+                enc.write.extend_ssh_string(b"keepalive@openssh.com");
                 enc.write.push(want_reply as u8);
             });
         }

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -262,6 +262,9 @@ pub enum Error {
     #[error("Failed to decrypt a packet")]
     DecryptionError,
 
+    #[error("The request was rejected by the other party")]
+    RequestDenied,
+
     #[error(transparent)]
     Keys(#[from] russh_keys::Error),
 

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -1059,6 +1059,22 @@ impl Session {
 
                 Ok(())
             }
+            Some(&msg::REQUEST_SUCCESS) => {
+                trace!("Global Request Success");
+                Ok(())
+            }
+            Some(&msg::REQUEST_FAILURE) => {
+                // Right now, the only global request we send with a request for reply is keepalive,
+                // which just needs to be ignored.
+                // If there are other global requests with reply implemented,
+                // we'll need to build infrastructure to filter the expected request failures from the keepalive
+                // The following works as long as only a single keepalive request was sent before a reply:
+                // `if self.common.alive_timeouts > 0`
+                // since any data received will reset alive_timeouts back to zero,
+                // even if multiple keepalives will be processed due to TCP delivering all of them after connectivity was restored
+                trace!("Global Request Failure");
+                Ok(())
+            }
             m => {
                 debug!("unknown message received: {:?}", m);
                 Ok(())

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -29,7 +29,7 @@
 //! * Serving `ratatui` based TUI app to clients: [per-client](https://github.com/warp-tech/russh/blob/main/russh/examples/ratatui_app.rs), [shared](https://github.com/warp-tech/russh/blob/main/russh/examples/ratatui_shared_app.rs)
 
 use std;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::num::Wrapping;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -678,6 +678,7 @@ where
         pending_reads: Vec::new(),
         pending_len: 0,
         channels: HashMap::new(),
+        open_global_requests: VecDeque::new(),
     };
     let join = tokio::spawn(session.run(stream, handler));
 

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use log::debug;
 use russh_keys::encoding::{Encoding, Reader};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc::{unbounded_channel, Receiver, Sender, UnboundedReceiver};
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 
 use super::*;
 use crate::channels::{Channel, ChannelMsg, ChannelRef};
@@ -21,6 +21,7 @@ pub struct Session {
     pub(crate) pending_reads: Vec<CryptoVec>,
     pub(crate) pending_len: u32,
     pub(crate) channels: HashMap<ChannelId, ChannelRef>,
+    pub(crate) open_global_requests: VecDeque<GlobalRequestResponse>,
 }
 #[derive(Debug)]
 pub enum Msg {
@@ -47,10 +48,14 @@ pub enum Msg {
         channel_ref: ChannelRef,
     },
     TcpIpForward {
+        /// Provide a channel for the reply result to request a reply from the server
+        reply_channel: Option<oneshot::Sender<Option<u32>>>,
         address: String,
         port: u32,
     },
     CancelTcpIpForward {
+        /// Provide a channel for the reply result to request a reply from the server
+        reply_channel: Option<oneshot::Sender<bool>>,
         address: String,
         port: u32,
     },
@@ -149,19 +154,46 @@ impl Handle {
     }
 
     /// Notifies the client that it can open TCP/IP forwarding channels for a port.
-    pub async fn forward_tcpip(&self, address: String, port: u32) -> Result<(), ()> {
+    pub async fn forward_tcpip(&self, address: String, port: u32) -> Result<u32, ()> {
+        let (reply_send, reply_recv) = oneshot::channel();
         self.sender
-            .send(Msg::TcpIpForward { address, port })
+            .send(Msg::TcpIpForward {
+                reply_channel: Some(reply_send),
+                address,
+                port,
+            })
             .await
-            .map_err(|_| ())
+            .map_err(|_| ())?;
+
+        match reply_recv.await {
+            Ok(Some(port)) => Ok(port),
+            Ok(None) => Err(()), // crate::Error::RequestDenied
+            Err(e) => {
+                error!("Unable to receive TcpIpForward result: {e:?}");
+                Err(()) // crate::Error::Disconnect
+            }
+        }
     }
 
     /// Notifies the client that it can no longer open TCP/IP forwarding channel for a port.
     pub async fn cancel_forward_tcpip(&self, address: String, port: u32) -> Result<(), ()> {
+        let (reply_send, reply_recv) = oneshot::channel();
         self.sender
-            .send(Msg::CancelTcpIpForward { address, port })
+            .send(Msg::CancelTcpIpForward {
+                reply_channel: Some(reply_send),
+                address,
+                port,
+            })
             .await
-            .map_err(|_| ())
+            .map_err(|_| ())?;
+        match reply_recv.await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(()), // crate::Error::RequestDenied
+            Err(e) => {
+                error!("Unable to receive CancelTcpIpForward result: {e:?}");
+                Err(()) // crate::Error::Disconnect
+            }
+        }
     }
 
     /// Request a session channel (the most basic type of
@@ -473,11 +505,11 @@ impl Session {
                             let id = self.channel_open_x11(&originator_address, originator_port)?;
                             self.channels.insert(id, channel_ref);
                         }
-                        Some(Msg::TcpIpForward { address, port }) => {
-                            self.tcpip_forward(&address, port);
+                        Some(Msg::TcpIpForward { address, port, reply_channel }) => {
+                            self.tcpip_forward(&address, port, reply_channel);
                         }
-                        Some(Msg::CancelTcpIpForward { address, port }) => {
-                            self.cancel_tcpip_forward(&address, port);
+                        Some(Msg::CancelTcpIpForward { address, port, reply_channel }) => {
+                            self.cancel_tcpip_forward(&address, port, reply_channel);
                         }
                         Some(_) => {
                             // should be unreachable, since the receiver only gets
@@ -767,6 +799,8 @@ impl Session {
     pub fn keepalive_request(&mut self) {
         let want_reply = u8::from(true);
         if let Some(ref mut enc) = self.common.encrypted {
+            self.open_global_requests
+                .push_back(GlobalRequestResponse::Keepalive);
             push_packet!(enc.write, {
                 enc.write.push(msg::GLOBAL_REQUEST);
                 enc.write.extend_ssh_string(b"keepalive@openssh.com");
@@ -922,12 +956,23 @@ impl Session {
     /// Requests that the client forward connections to the given host and port.
     /// See [RFC4254](https://tools.ietf.org/html/rfc4254#section-7). The client
     /// will open forwarded_tcpip channels for each connection.
-    pub fn tcpip_forward(&mut self, address: &str, port: u32) {
+    pub fn tcpip_forward(
+        &mut self,
+        address: &str,
+        port: u32,
+        reply_channel: Option<oneshot::Sender<Option<u32>>>,
+    ) {
         if let Some(ref mut enc) = self.common.encrypted {
+            let want_reply = reply_channel.is_some();
+            if let Some(reply_channel) = reply_channel {
+                self.open_global_requests.push_back(
+                    crate::session::GlobalRequestResponse::TcpIpForward(reply_channel),
+                );
+            }
             push_packet!(enc.write, {
                 enc.write.push(msg::GLOBAL_REQUEST);
                 enc.write.extend_ssh_string(b"tcpip-forward");
-                enc.write.push(0);
+                enc.write.push(want_reply as u8);
                 enc.write.extend_ssh_string(address.as_bytes());
                 enc.write.push_u32_be(port);
             });
@@ -935,12 +980,23 @@ impl Session {
     }
 
     /// Cancels a previously tcpip_forward request.
-    pub fn cancel_tcpip_forward(&mut self, address: &str, port: u32) {
+    pub fn cancel_tcpip_forward(
+        &mut self,
+        address: &str,
+        port: u32,
+        reply_channel: Option<oneshot::Sender<bool>>,
+    ) {
         if let Some(ref mut enc) = self.common.encrypted {
+            let want_reply = reply_channel.is_some();
+            if let Some(reply_channel) = reply_channel {
+                self.open_global_requests.push_back(
+                    crate::session::GlobalRequestResponse::CancelTcpIpForward(reply_channel),
+                );
+            }
             push_packet!(enc.write, {
                 enc.write.push(msg::GLOBAL_REQUEST);
                 enc.write.extend_ssh_string(b"cancel-tcpip-forward");
-                enc.write.push(0);
+                enc.write.push(want_reply as u8);
                 enc.write.extend_ssh_string(address.as_bytes());
                 enc.write.push_u32_be(port);
             });

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -21,6 +21,7 @@ use byteorder::{BigEndian, ByteOrder};
 use log::{debug, trace};
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::Encoding;
+use tokio::sync::oneshot;
 
 use crate::cipher::SealingKey;
 use crate::kex::KexAlgorithm;
@@ -614,4 +615,13 @@ pub(crate) struct NewKeys {
     pub cipher: cipher::CipherPair,
     pub session_id: CryptoVec,
     pub sent: bool,
+}
+
+pub(crate) enum GlobalRequestResponse {
+    /// request was for Keepalive, ignore result
+    Keepalive,
+    /// request was for TcpIpForward, sends Some(port) for success or None for failure
+    TcpIpForward(oneshot::Sender<Option<u32>>),
+    /// request was for CancelTcpIpForward, sends true for success or false for failure
+    CancelTcpIpForward(oneshot::Sender<bool>),
 }


### PR DESCRIPTION
Right now, the handling to global request responses differs between Client and Server.

At the moment, the only situation where we receive those is in response to keepalive requests (everything else is sent with want_reply false), so I've also added a little bit of an explaining comment instead of a leftover "todo".

The old `if` is not really sufficient to filter for global requests in response to keepalives, since the value it checks, `alive_timeouts` is reset to 0 with the first response, but due to TCP resends multiple keepalives and their responses might arrive.

This also stops russh client from repeatedly sending an `info`-level log message about an unknown packet when keepalive responses are received, downgrading unknown messages to `debug` in general (same as it was in server already), and `REQUEST_SUCCESS` / `REQUEST_FAILURE` to `trace`.