### PR TITLE
Fix compilation error when using without the flate2 feature

### DIFF
--- a/russh/src/compression.rs
+++ b/russh/src/compression.rs
@@ -71,7 +71,7 @@ impl Compress {
         &mut self,
         input: &'a [u8],
         _: &'a mut russh_cryptovec::CryptoVec,
-    ) -> Result<&'a [u8], Error> {
+    ) -> Result<&'a [u8], crate::Error> {
         Ok(input)
     }
 }
@@ -82,7 +82,7 @@ impl Decompress {
         &mut self,
         input: &'a [u8],
         _: &'a mut russh_cryptovec::CryptoVec,
-    ) -> Result<&'a [u8], Error> {
+    ) -> Result<&'a [u8], crate::Error> {
         Ok(input)
     }
 }

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -284,9 +284,11 @@ pub enum Error {
     Utf8(#[from] std::str::Utf8Error),
 
     #[error(transparent)]
+    #[cfg(feature = "flate2")]
     Compress(#[from] flate2::CompressError),
 
     #[error(transparent)]
+    #[cfg(feature = "flate2")]
     Decompress(#[from] flate2::DecompressError),
 
     #[error(transparent)]


### PR DESCRIPTION
When compiling without the default features, the compilation of russh fail with message concerning unknown Error type in compression.rs and unknown flate2 crate in lib.rs (when defining the error type)

This PR specify the same Error type as the flate2-featured Compression/Decompression function and disable error cases specific to flate2.