### PR TITLE
Implement ecdsa-sha2-nistp{256,384,521}

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ This is a fork of [Thrussh](https://nest.pijul.com/pijul/thrussh) by Pierre-Éti
   * `rsa-sha2-256`
   * `rsa-sha2-512`
   * `ssh-rsa` ✨
+  * `ecdsa-sha2-nistp256` ✨
+  * `ecdsa-sha2-nistp384` ✨
+  * `ecdsa-sha2-nistp521` ✨
 * Dependency updates
 * OpenSSH keepalive request handling ✨
 * OpenSSH agent forwarding channels ✨

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -62,12 +62,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha1 = "0.10"
 sha2 = "0.10"
 thiserror = "1.0"
-tokio = { version = "1.17.0", features = [
-  "io-util",
-  "rt-multi-thread",
-  "time",
-  "net",
-] }
+tokio = { version = "1.17.0", features = ["io-util", "rt-multi-thread", "time", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 typenum = "1.17"
 yasna = { version = "0.5.0", features = ["bit-vec", "num-bigint"] }
@@ -78,6 +73,7 @@ vendored-openssl = ["openssl", "openssl/vendored"]
 [dev-dependencies]
 env_logger = "0.10"
 tempdir = "0.3"
+tokio = { version = "1.17.0", features = ["test-util", "macros", "process"] }
 
 [package.metadata.docs.rs]
 features = ["openssl"]

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -13,6 +13,7 @@ include = [
   "src/agent/client.rs",
   "src/bcrypt_pbkdf.rs",
   "src/blowfish.rs",
+  "src/ec.rs",
   "src/encoding.rs",
   "src/format/mod.rs",
   "src/format/openssh.rs",
@@ -39,7 +40,9 @@ block-padding = { version = "0.3", features = ["std"] }
 byteorder = "1.4"
 data-encoding = "2.3"
 dirs = "5.0"
+ecdsa = "0.16"
 ed25519-dalek = { version= "2.0", features = ["rand_core"] }
+elliptic-curve = "0.13"
 futures = "0.3"
 hmac = "0.12"
 inout = { version = "0.1", features = ["std"] }
@@ -49,9 +52,10 @@ num-bigint = "0.4"
 num-integer = "0.1"
 openssl = { version = "0.10", optional = true }
 p256 = "0.13"
+p384 = "0.13"
 p521 = "0.13"
 pbkdf2 = "0.11"
-rand = "0.7"
+rand = "0.8"
 rand_core = { version = "0.6.4", features = ["std"] }
 russh-cryptovec = { version = "0.7.0", path = "../cryptovec" }
 serde = { version = "1.0", features = ["derive"] }
@@ -65,6 +69,7 @@ tokio = { version = "1.17.0", features = [
   "net",
 ] }
 tokio-stream = { version = "0.1", features = ["net"] }
+typenum = "1.17"
 yasna = { version = "0.5.0", features = ["bit-vec", "num-bigint"] }
 
 [features]

--- a/russh-keys/src/agent/client.rs
+++ b/russh-keys/src/agent/client.rs
@@ -103,6 +103,8 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
         key: &key::KeyPair,
         constraints: &[Constraint],
     ) -> Result<(), Error> {
+        // See IETF draft-miller-ssh-agent-13, section 3.2 for format.
+        // https://datatracker.ietf.org/doc/html/draft-miller-ssh-agent
         self.buf.clear();
         self.buf.resize(4);
         if constraints.is_empty() {
@@ -137,6 +139,14 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
                 self.buf.extend_ssh_mpint(&key.p().unwrap().to_vec());
                 self.buf.extend_ssh_mpint(&key.q().unwrap().to_vec());
                 self.buf.extend_ssh_string(b"");
+            }
+            key::KeyPair::EC { ref key } => {
+                self.buf.extend_ssh_string(key.algorithm().as_bytes());
+                self.buf.extend_ssh_string(key.ident().as_bytes());
+                self.buf
+                    .extend_ssh_string(&key.to_public_key().to_sec1_bytes());
+                self.buf.extend_ssh_mpint(&key.to_secret_bytes());
+                self.buf.extend_ssh_string(b""); // comment
             }
         }
         if !constraints.is_empty() {
@@ -275,21 +285,16 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
                     b"ssh-ed25519" => keys.push(PublicKey::Ed25519(
                         ed25519_dalek::VerifyingKey::try_from(r.read_string()?)?,
                     )),
-                    b"ecdsa-sha2-nistp256" => {
+                    crate::KEYTYPE_ECDSA_SHA2_NISTP256
+                    | crate::KEYTYPE_ECDSA_SHA2_NISTP384
+                    | crate::KEYTYPE_ECDSA_SHA2_NISTP521 => {
                         let curve = r.read_string()?;
-                        if curve != b"nistp256" {
-                            return Err(Error::EcdsaKeyError(p256::elliptic_curve::Error));
+                        let sec1_bytes = r.read_string()?;
+                        let key = crate::ec::PublicKey::from_sec1_bytes(t, sec1_bytes)?;
+                        if curve != key.ident().as_bytes() {
+                            return Err(Error::CouldNotReadKey);
                         }
-                        let key = r.read_string()?;
-                        keys.push(PublicKey::P256(p256::PublicKey::from_sec1_bytes(key)?));
-                    }
-                    b"ecdsa-sha2-nistp512" => {
-                        let curve = r.read_string()?;
-                        if curve != b"nistp521" {
-                            return Err(Error::EcdsaKeyError(p521::elliptic_curve::Error));
-                        }
-                        let key = r.read_string()?;
-                        keys.push(PublicKey::P521(p521::PublicKey::from_sec1_bytes(key)?));
+                        keys.push(PublicKey::EC { key })
                     }
                     t => {
                         info!("Unsupported key type: {:?}", std::str::from_utf8(t))
@@ -550,7 +555,7 @@ fn key_blob(public: &key::PublicKey, buf: &mut CryptoVec) -> Result<(), Error> {
             #[allow(clippy::indexing_slicing)] // length is known
             BigEndian::write_u32(&mut buf[5..], (len1 - len0) as u32);
         }
-        PublicKey::P256(_) | PublicKey::P521(_) => {
+        PublicKey::EC { .. } => {
             buf.extend_ssh_string(&public.public_key_bytes());
         }
     }

--- a/russh-keys/src/ec.rs
+++ b/russh-keys/src/ec.rs
@@ -1,0 +1,262 @@
+use crate::key::safe_rng;
+use crate::Error;
+use elliptic_curve::{Curve, CurveArithmetic, FieldBytes, FieldBytesSize};
+
+// p521::{SigningKey, VerifyingKey} are wrapped versions and do not provide PartialEq and Eq, hence
+// we make our own type alias here.
+mod local_p521 {
+    use rand_core::CryptoRngCore;
+    use sha2::{Digest, Sha512};
+
+    pub type NistP521 = p521::NistP521;
+    pub type VerifyingKey = ecdsa::VerifyingKey<NistP521>;
+    pub type SigningKey = ecdsa::SigningKey<NistP521>;
+    pub type Signature = ecdsa::Signature<NistP521>;
+    pub type Result<T> = ecdsa::Result<T>;
+
+    // Implement signing because p521::NistP521 does not implement DigestPrimitive trait.
+    pub fn try_sign_with_rng(
+        key: &SigningKey,
+        rng: &mut impl CryptoRngCore,
+        msg: &[u8],
+    ) -> Result<Signature> {
+        use ecdsa::hazmat::{bits2field, sign_prehashed};
+        use elliptic_curve::Field;
+        let prehash = Sha512::digest(msg);
+        let z = bits2field::<NistP521>(&prehash)?;
+        let k = p521::Scalar::random(rng);
+        sign_prehashed(key.as_nonzero_scalar().as_ref(), k, &z).map(|sig| sig.0)
+    }
+
+    // Implement verifying because ecdsa::VerifyingKey<p521::NistP521> does not satisfy the trait
+    // bound requirements of the DigestVerifier's implementation in ecdsa crate.
+    pub fn verify(key: &VerifyingKey, msg: &[u8], signature: &Signature) -> Result<()> {
+        use ecdsa::signature::hazmat::PrehashVerifier;
+        key.verify_prehash(&Sha512::digest(msg), signature)
+    }
+}
+
+const CURVE_NISTP256: &str = "nistp256";
+const CURVE_NISTP384: &str = "nistp384";
+const CURVE_NISTP521: &str = "nistp521";
+
+/// An ECC public key.
+#[derive(Clone, Eq, PartialEq)]
+pub enum PublicKey {
+    P256(p256::ecdsa::VerifyingKey),
+    P384(p384::ecdsa::VerifyingKey),
+    P521(local_p521::VerifyingKey),
+}
+
+impl PublicKey {
+    /// Returns the elliptic curve domain parameter identifiers defined in RFC 5656 section 6.1.
+    pub fn ident(&self) -> &'static str {
+        match self {
+            Self::P256(_) => CURVE_NISTP256,
+            Self::P384(_) => CURVE_NISTP384,
+            Self::P521(_) => CURVE_NISTP521,
+        }
+    }
+
+    /// Returns the ECC public key algorithm name defined in RFC 5656 section 6.2, in the form of
+    /// `"ecdsa-sha2-[identifier]"`.
+    pub fn algorithm(&self) -> &'static str {
+        match self {
+            Self::P256(_) => crate::ECDSA_SHA2_NISTP256,
+            Self::P384(_) => crate::ECDSA_SHA2_NISTP384,
+            Self::P521(_) => crate::ECDSA_SHA2_NISTP521,
+        }
+    }
+
+    /// Creates a `PrivateKey` from algorithm name and SEC1-encoded point on curve.
+    pub fn from_sec1_bytes(algorithm: &[u8], bytes: &[u8]) -> Result<Self, Error> {
+        match algorithm {
+            crate::KEYTYPE_ECDSA_SHA2_NISTP256 => Ok(Self::P256(
+                p256::ecdsa::VerifyingKey::from_sec1_bytes(bytes)?,
+            )),
+            crate::KEYTYPE_ECDSA_SHA2_NISTP384 => Ok(Self::P384(
+                p384::ecdsa::VerifyingKey::from_sec1_bytes(bytes)?,
+            )),
+            crate::KEYTYPE_ECDSA_SHA2_NISTP521 => Ok(Self::P521(
+                local_p521::VerifyingKey::from_sec1_bytes(bytes)?,
+            )),
+            _ => Err(Error::UnsupportedKeyType {
+                key_type_string: String::from_utf8(algorithm.to_vec())
+                    .unwrap_or_else(|_| format!("{algorithm:?}")),
+                key_type_raw: algorithm.to_vec(),
+            }),
+        }
+    }
+
+    /// Returns the SEC1-encoded public curve point.
+    pub fn to_sec1_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::P256(key) => key.to_encoded_point(false).as_bytes().to_vec(),
+            Self::P384(key) => key.to_encoded_point(false).as_bytes().to_vec(),
+            Self::P521(key) => key.to_encoded_point(false).as_bytes().to_vec(),
+        }
+    }
+
+    /// Verifies message against signature `(r, s)` using the associated digest algorithm.
+    pub fn verify(&self, msg: &[u8], r: &[u8], s: &[u8]) -> Result<(), Error> {
+        use ecdsa::signature::Verifier;
+        match self {
+            Self::P256(key) => {
+                key.verify(msg, &signature_from_scalar_bytes::<p256::NistP256>(r, s)?)
+            }
+            Self::P384(key) => {
+                key.verify(msg, &signature_from_scalar_bytes::<p384::NistP384>(r, s)?)
+            }
+            Self::P521(key) => local_p521::verify(
+                key,
+                msg,
+                &signature_from_scalar_bytes::<p521::NistP521>(r, s)?,
+            ),
+        }
+        .map_err(Error::from)
+    }
+}
+
+impl std::fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::P256(_) => write!(f, "P256"),
+            Self::P384(_) => write!(f, "P384"),
+            Self::P521(_) => write!(f, "P521"),
+        }
+    }
+}
+
+/// An ECC private key.
+#[derive(Clone, Eq, PartialEq)]
+pub enum PrivateKey {
+    P256(p256::ecdsa::SigningKey),
+    P384(p384::ecdsa::SigningKey),
+    P521(local_p521::SigningKey),
+}
+
+impl PrivateKey {
+    /// Creates a `PrivateKey` with algorithm name and scalar.
+    pub fn new_from_secret_scalar(algorithm: &[u8], scalar: &[u8]) -> Result<Self, Error> {
+        match algorithm {
+            crate::KEYTYPE_ECDSA_SHA2_NISTP256 => {
+                Ok(Self::P256(p256::ecdsa::SigningKey::from_slice(scalar)?))
+            }
+            crate::KEYTYPE_ECDSA_SHA2_NISTP384 => {
+                Ok(Self::P384(p384::ecdsa::SigningKey::from_slice(scalar)?))
+            }
+            crate::KEYTYPE_ECDSA_SHA2_NISTP521 => {
+                Ok(Self::P521(local_p521::SigningKey::from_slice(scalar)?))
+            }
+            _ => Err(Error::UnsupportedKeyType {
+                key_type_string: String::from_utf8(algorithm.to_vec())
+                    .unwrap_or_else(|_| format!("{algorithm:?}")),
+                key_type_raw: algorithm.to_vec(),
+            }),
+        }
+    }
+
+    /// Returns the elliptic curve domain parameter identifiers defined in RFC 5656 section 6.1.
+    pub fn ident(&self) -> &'static str {
+        match self {
+            Self::P256(_) => CURVE_NISTP256,
+            Self::P384(_) => CURVE_NISTP384,
+            Self::P521(_) => CURVE_NISTP521,
+        }
+    }
+
+    /// Returns the ECC public key algorithm name defined in RFC 5656 section 6.2, in the form of
+    /// `"ecdsa-sha2-[identifier]"`.
+    pub fn algorithm(&self) -> &'static str {
+        match self {
+            Self::P256(_) => crate::ECDSA_SHA2_NISTP256,
+            Self::P384(_) => crate::ECDSA_SHA2_NISTP384,
+            Self::P521(_) => crate::ECDSA_SHA2_NISTP521,
+        }
+    }
+
+    /// Returns the public key.
+    pub fn to_public_key(&self) -> PublicKey {
+        match self {
+            Self::P256(key) => PublicKey::P256(*key.verifying_key()),
+            Self::P384(key) => PublicKey::P384(*key.verifying_key()),
+            Self::P521(key) => PublicKey::P521(*key.verifying_key()),
+        }
+    }
+
+    /// Returns the secret scalar in bytes.
+    pub fn to_secret_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::P256(key) => key.to_bytes().to_vec(),
+            Self::P384(key) => key.to_bytes().to_vec(),
+            Self::P521(key) => key.to_bytes().to_vec(),
+        }
+    }
+
+    /// Sign the message with associated digest algorithm.
+    pub fn try_sign(&self, msg: &[u8]) -> Result<(Vec<u8>, Vec<u8>), Error> {
+        use ecdsa::signature::RandomizedSigner;
+        Ok(match self {
+            Self::P256(key) => {
+                signature_to_scalar_bytes(key.try_sign_with_rng(&mut safe_rng(), msg)?)
+            }
+            Self::P384(key) => {
+                signature_to_scalar_bytes(key.try_sign_with_rng(&mut safe_rng(), msg)?)
+            }
+            Self::P521(key) => {
+                signature_to_scalar_bytes(local_p521::try_sign_with_rng(key, &mut safe_rng(), msg)?)
+            }
+        })
+    }
+}
+
+impl std::fmt::Debug for PrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::P256(_) => write!(f, "P256 {{ (hidden) }}"),
+            Self::P384(_) => write!(f, "P384 {{ (hidden) }}"),
+            Self::P521(_) => write!(f, "P521 {{ (hidden) }}"),
+        }
+    }
+}
+
+fn try_field_bytes_from_mpint<C>(b: &[u8]) -> Option<FieldBytes<C>>
+where
+    C: Curve + CurveArithmetic,
+{
+    use typenum::Unsigned;
+    let size = FieldBytesSize::<C>::to_usize();
+    assert!(size > 0);
+    #[allow(clippy::indexing_slicing)] // Length checked
+    if b.len() == size + 1 && b[0] == 0 {
+        Some(FieldBytes::<C>::clone_from_slice(&b[1..]))
+    } else if b.len() == size {
+        Some(FieldBytes::<C>::clone_from_slice(b))
+    } else if b.len() < size {
+        let mut fb: FieldBytes<C> = Default::default();
+        fb.as_mut_slice()[size - b.len()..].clone_from_slice(b);
+        Some(fb)
+    } else {
+        None
+    }
+}
+
+fn signature_from_scalar_bytes<C>(r: &[u8], s: &[u8]) -> Result<ecdsa::Signature<C>, Error>
+where
+    C: Curve + CurveArithmetic + elliptic_curve::PrimeCurve,
+    ecdsa::SignatureSize<C>: elliptic_curve::generic_array::ArrayLength<u8>,
+{
+    Ok(ecdsa::Signature::<C>::from_scalars(
+        try_field_bytes_from_mpint::<C>(r).ok_or(Error::InvalidSignature)?,
+        try_field_bytes_from_mpint::<C>(s).ok_or(Error::InvalidSignature)?,
+    )?)
+}
+
+fn signature_to_scalar_bytes<C>(sig: ecdsa::Signature<C>) -> (Vec<u8>, Vec<u8>)
+where
+    C: Curve + CurveArithmetic + elliptic_curve::PrimeCurve,
+    ecdsa::SignatureSize<C>: elliptic_curve::generic_array::ArrayLength<u8>,
+{
+    let (r, s) = sig.split_bytes();
+    (r.to_vec(), s.to_vec())
+}

--- a/russh-keys/src/format/openssh.rs
+++ b/russh-keys/src/format/openssh.rs
@@ -8,7 +8,7 @@ use ctr::Ctr64BE;
 use openssl::bn::BigNum;
 
 use crate::encoding::Reader;
-use crate::{key, Error, KEYTYPE_ED25519, KEYTYPE_RSA};
+use crate::{ec, key, Error, KEYTYPE_ED25519, KEYTYPE_RSA};
 
 /// Decode a secret key given in the OpenSSH format, deciphering it if
 /// needed using the supplied password.
@@ -79,6 +79,27 @@ pub fn decode_openssh(secret: &[u8], password: Option<&str>) -> Result<key::KeyP
                         hash: key::SignatureHash::SHA2_512,
                     });
                 }
+            } else if key_type == crate::KEYTYPE_ECDSA_SHA2_NISTP256
+                || key_type == crate::KEYTYPE_ECDSA_SHA2_NISTP384
+                || key_type == crate::KEYTYPE_ECDSA_SHA2_NISTP521
+            {
+                let ident = position.read_string()?;
+                let pubkey = position.read_string()?;
+                let seckey = position.read_mpint()?;
+                let _comment = position.read_string()?;
+
+                let key = ec::PrivateKey::new_from_secret_scalar(key_type, seckey)?;
+
+                if ident != key.ident().as_bytes() {
+                    return Err(Error::CouldNotReadKey);
+                }
+
+                let pubkey = ec::PublicKey::from_sec1_bytes(key_type, pubkey)?;
+                if pubkey != key.to_public_key() {
+                    return Err(Error::CouldNotReadKey);
+                }
+
+                return Ok(key::KeyPair::EC { key });
             } else {
                 return Err(Error::UnsupportedKeyType {
                     key_type_string: String::from_utf8(key_type.to_vec())

--- a/russh-keys/src/format/pkcs5.rs
+++ b/russh-keys/src/format/pkcs5.rs
@@ -3,7 +3,7 @@ use aes::*;
 use super::Encryption;
 use crate::{key, Error};
 
-/// Decode a secret key in the PKCS#5 format, possible deciphering it
+/// Decode a secret key in the PKCS#5 format, possibly deciphering it
 /// using the supplied password.
 #[cfg(feature = "openssl")]
 pub fn decode_pkcs5(

--- a/russh-keys/src/format/pkcs8.rs
+++ b/russh-keys/src/format/pkcs8.rs
@@ -25,6 +25,10 @@ const AES256CBC: &[u64] = &[2, 16, 840, 1, 101, 3, 4, 1, 42];
 const ED25519: &[u64] = &[1, 3, 101, 112];
 #[cfg(feature = "openssl")]
 const RSA: &[u64] = &[1, 2, 840, 113549, 1, 1, 1];
+const EC_PUBLIC_KEY: &[u64] = &[1, 2, 840, 10045, 2, 1];
+const SECP256R1: &[u64] = &[1, 2, 840, 10045, 3, 1, 7];
+const SECP384R1: &[u64] = &[1, 3, 132, 0, 34];
+const SECP521R1: &[u64] = &[1, 3, 132, 0, 35];
 
 /// Decode a PKCS#8-encoded private key.
 pub fn decode_pkcs8(ciphertext: &[u8], password: Option<&[u8]>) -> Result<key::KeyPair, Error> {
@@ -165,7 +169,7 @@ fn read_key_v1(reader: &mut BERReaderSeq) -> Result<key::KeyPair, Error> {
 }
 
 #[cfg(feature = "openssl")]
-fn write_key_v0(writer: &mut yasna::DERWriterSeq, key: &Rsa<Private>) {
+fn write_key_v0_rsa(writer: &mut yasna::DERWriterSeq, key: &Rsa<Private>) {
     writer.next().write_u32(0);
     // write OID
     writer.next().write_sequence(|writer| {
@@ -206,49 +210,131 @@ fn write_key_v0(writer: &mut yasna::DERWriterSeq, key: &Rsa<Private>) {
     writer.next().write_bytes(&bytes);
 }
 
-#[cfg(feature = "openssl")]
-fn read_key_v0(reader: &mut BERReaderSeq) -> Result<key::KeyPair, Error> {
-    let oid = reader.next().read_sequence(|reader| {
-        let oid = reader.next().read_oid()?;
-        reader.next().read_null()?;
-        Ok(oid)
-    })?;
-    if oid.components().as_slice() == RSA {
-        let seq = &reader.next().read_bytes()?;
-        let rsa: Result<Rsa<Private>, Error> = yasna::parse_der(seq, |reader| {
-            reader.read_sequence(|reader| {
-                let version = reader.next().read_u32()?;
-                if version != 0 {
-                    return Ok(Err(Error::CouldNotReadKey));
-                }
-                use openssl::bn::BigNum;
-                let mut read_key = || -> Result<Rsa<Private>, Error> {
-                    Ok(Rsa::from_private_components(
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                        BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
-                    )?)
-                };
-                Ok(read_key())
-            })
-        })?;
-        Ok(key::KeyPair::RSA {
-            key: rsa?,
-            hash: SignatureHash::SHA2_256,
+fn write_key_v0_ec(writer: &mut yasna::DERWriterSeq, key: &crate::ec::PrivateKey) {
+    writer.next().write_u32(0);
+    writer.next().write_sequence(|writer| {
+        writer
+            .next()
+            .write_oid(&ObjectIdentifier::from_slice(EC_PUBLIC_KEY));
+        writer
+            .next()
+            .write_oid(&ObjectIdentifier::from_slice(match key {
+                crate::ec::PrivateKey::P256(_) => SECP256R1,
+                crate::ec::PrivateKey::P384(_) => SECP384R1,
+                crate::ec::PrivateKey::P521(_) => SECP521R1,
+            }))
+    });
+    let bytes = yasna::construct_der(|writer| {
+        #[allow(clippy::unwrap_used)] // key is known to be private
+        writer.write_sequence(|writer| {
+            writer.next().write_u32(1);
+            writer.next().write_bytes(&key.to_secret_bytes());
+            writer
+                .next()
+                .write_tagged(yasna::Tag::context(1), |writer| {
+                    writer.write_bitvec(&BitVec::from_bytes(&key.to_public_key().to_sec1_bytes()))
+                });
         })
-    } else {
-        Err(Error::CouldNotReadKey)
-    }
+    });
+    writer.next().write_bytes(&bytes);
 }
 
-#[cfg(not(feature = "openssl"))]
-fn read_key_v0(_: &mut BERReaderSeq) -> Result<key::KeyPair, Error> {
-    Err(Error::CouldNotReadKey)
+// Utility enum used for reading v0 key.
+enum KeyType {
+    Unknown(ObjectIdentifier),
+    #[cfg(feature = "openssl")]
+    #[allow(clippy::upper_case_acronyms)]
+    RSA,
+    EC(ObjectIdentifier),
+}
+
+fn read_key_v0(reader: &mut BERReaderSeq) -> Result<key::KeyPair, Error> {
+    let key_type = reader.next().read_sequence(|reader| {
+        let oid = reader.next().read_oid()?;
+        Ok(match oid.components().as_slice() {
+            #[cfg(feature = "openssl")]
+            RSA => {
+                reader.next().read_null()?;
+                KeyType::RSA
+            }
+            EC_PUBLIC_KEY => KeyType::EC(reader.next().read_oid()?),
+            _ => KeyType::Unknown(oid),
+        })
+    })?;
+    match key_type {
+        KeyType::Unknown(_) => Err(Error::CouldNotReadKey),
+        #[cfg(feature = "openssl")]
+        KeyType::RSA => {
+            let seq = &reader.next().read_bytes()?;
+            let rsa: Result<Rsa<Private>, Error> = yasna::parse_der(seq, |reader| {
+                reader.read_sequence(|reader| {
+                    let version = reader.next().read_u32()?;
+                    if version != 0 {
+                        return Ok(Err(Error::CouldNotReadKey));
+                    }
+                    use openssl::bn::BigNum;
+                    let mut read_key = || -> Result<Rsa<Private>, Error> {
+                        Ok(Rsa::from_private_components(
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                            BigNum::from_slice(&reader.next().read_biguint()?.to_bytes_be())?,
+                        )?)
+                    };
+                    Ok(read_key())
+                })
+            })?;
+            Ok(key::KeyPair::RSA {
+                key: rsa?,
+                hash: SignatureHash::SHA2_256,
+            })
+        }
+        KeyType::EC(oid) => {
+            let private_key = reader.next().read_bytes()?;
+            let (version, secret_key, public_key) = yasna::parse_der(&private_key, |reader| {
+                reader.read_sequence(|reader| {
+                    // Per RFC 5915, section 3:
+                    // ECPrivateKey ::= SEQUENCE {
+                    //   version        INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
+                    //   privateKey     OCTET STRING,
+                    //   parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
+                    //   publicKey  [1] BIT STRING OPTIONAL
+                    // }
+                    let version = reader.next().read_u64()?;
+                    let secret_key = reader.next().read_bytes()?;
+                    let _named_curve = reader.read_optional(|reader| {
+                        reader.read_tagged(yasna::Tag::context(0), |reader| reader.read_oid())
+                    })?;
+                    let public_key = reader.read_optional(|reader| {
+                        reader.read_tagged(yasna::Tag::context(1), |reader| reader.read_bitvec())
+                    })?;
+                    Ok((version, secret_key, public_key))
+                })
+            })?;
+            if version != 1 {
+                return Err(Error::CouldNotReadKey);
+            }
+            let key = crate::ec::PrivateKey::new_from_secret_scalar(
+                match oid.components().as_slice() {
+                    SECP256R1 => crate::KEYTYPE_ECDSA_SHA2_NISTP256,
+                    SECP384R1 => crate::KEYTYPE_ECDSA_SHA2_NISTP384,
+                    SECP521R1 => crate::KEYTYPE_ECDSA_SHA2_NISTP521,
+                    _ => return Err(Error::CouldNotReadKey),
+                },
+                &secret_key,
+            )?;
+            if let Some(public_key) = public_key {
+                if key.to_public_key().to_sec1_bytes() != public_key.to_bytes() {
+                    return Err(Error::CouldNotReadKey);
+                }
+            }
+            Ok(key::KeyPair::EC { key })
+        }
+    }
 }
 
 #[test]
@@ -264,6 +350,7 @@ fn test_read_write_pkcs8() {
     let key = decode_pkcs8(&ciphertext, Some(password)).unwrap();
     match key {
         key::KeyPair::Ed25519 { .. } => println!("Ed25519"),
+        key::KeyPair::EC { .. } => println!("EC"),
         #[cfg(feature = "openssl")]
         key::KeyPair::RSA { .. } => println!("RSA"),
     }
@@ -317,7 +404,8 @@ pub fn encode_pkcs8(key: &key::KeyPair) -> Vec<u8> {
         writer.write_sequence(|writer| match *key {
             key::KeyPair::Ed25519(ref pair) => write_key_v1(writer, pair),
             #[cfg(feature = "openssl")]
-            key::KeyPair::RSA { ref key, .. } => write_key_v0(writer, key),
+            key::KeyPair::RSA { ref key, .. } => write_key_v0_rsa(writer, key),
+            key::KeyPair::EC { ref key, .. } => write_key_v0_ec(writer, key),
         })
     })
 }

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -38,6 +38,8 @@ impl AsRef<str> for Name {
 
 /// The name of the ecdsa-sha2-nistp256 algorithm for SSH.
 pub const ECDSA_SHA2_NISTP256: Name = Name("ecdsa-sha2-nistp256");
+/// The name of the ecdsa-sha2-nistp384 algorithm for SSH.
+pub const ECDSA_SHA2_NISTP384: Name = Name("ecdsa-sha2-nistp384");
 /// The name of the ecdsa-sha2-nistp521 algorithm for SSH.
 pub const ECDSA_SHA2_NISTP521: Name = Name("ecdsa-sha2-nistp521");
 /// The name of the Ed25519 algorithm for SSH.
@@ -55,7 +57,7 @@ impl Name {
     /// Base name of the private key file for a key name.
     pub fn identity_file(&self) -> &'static str {
         match *self {
-            ECDSA_SHA2_NISTP256 | ECDSA_SHA2_NISTP521 => "id_ecdsa",
+            ECDSA_SHA2_NISTP256 | ECDSA_SHA2_NISTP384 | ECDSA_SHA2_NISTP521 => "id_ecdsa",
             ED25519 => "id_ed25519",
             RSA_SHA2_512 => "id_rsa",
             RSA_SHA2_256 => "id_rsa",

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -17,12 +17,11 @@ use std::convert::TryFrom;
 use ed25519_dalek::{Signer, Verifier};
 #[cfg(feature = "openssl")]
 use openssl::pkey::{Private, Public};
-use p256::elliptic_curve::generic_array::typenum::Unsigned;
-use p521::elliptic_curve::generic_array::GenericArray;
 use rand_core::OsRng;
 use russh_cryptovec::CryptoVec;
 use serde::{Deserialize, Serialize};
 
+use crate::ec;
 use crate::encoding::{Encoding, Reader};
 pub use crate::signature::*;
 use crate::Error;
@@ -125,9 +124,7 @@ pub enum PublicKey {
         hash: SignatureHash,
     },
     #[doc(hidden)]
-    P256(p256::PublicKey),
-    #[doc(hidden)]
-    P521(p521::PublicKey),
+    EC { key: ec::PublicKey },
 }
 
 impl PartialEq for PublicKey {
@@ -136,8 +133,7 @@ impl PartialEq for PublicKey {
             #[cfg(feature = "openssl")]
             (Self::RSA { key: a, .. }, Self::RSA { key: b, .. }) => a == b,
             (Self::Ed25519(a), Self::Ed25519(b)) => a == b,
-            (Self::P256(a), Self::P256(b)) => a == b,
-            (Self::P521(a), Self::P521(b)) => a == b,
+            (Self::EC { key: a }, Self::EC { key: b }) => a == b,
             _ => false,
         }
     }
@@ -217,29 +213,24 @@ impl PublicKey {
                     unreachable!()
                 }
             }
-            b"ecdsa-sha2-nistp256" => {
+            crate::KEYTYPE_ECDSA_SHA2_NISTP256
+            | crate::KEYTYPE_ECDSA_SHA2_NISTP384
+            | crate::KEYTYPE_ECDSA_SHA2_NISTP521 => {
                 let mut p = pubkey.reader(0);
                 let key_algo = p.read_string()?;
                 let curve = p.read_string()?;
-                if key_algo != b"ecdsa-sha2-nistp256" || curve != b"nistp256" {
+                let sec1_bytes = p.read_string()?;
+
+                if key_algo != algo {
                     return Err(Error::CouldNotReadKey);
                 }
-                let sec1_bytes = p.read_string()?;
-                let key = p256::PublicKey::from_sec1_bytes(sec1_bytes)
-                    .map_err(|_| Error::CouldNotReadKey)?;
-                Ok(PublicKey::P256(key))
-            }
-            b"ecdsa-sha2-nistp521" => {
-                let mut p = pubkey.reader(0);
-                let key_algo = p.read_string()?;
-                let curve = p.read_string()?;
-                if key_algo != b"ecdsa-sha2-nistp521" || curve != b"nistp521" {
+
+                let key = ec::PublicKey::from_sec1_bytes(key_algo, sec1_bytes)?;
+                if curve != key.ident().as_bytes() {
                     return Err(Error::CouldNotReadKey);
                 }
-                let sec1_bytes = p.read_string()?;
-                let key = p521::PublicKey::from_sec1_bytes(sec1_bytes)
-                    .map_err(|_| Error::CouldNotReadKey)?;
-                Ok(PublicKey::P521(key))
+
+                Ok(PublicKey::EC { key })
             }
             _ => Err(Error::CouldNotReadKey),
         }
@@ -251,8 +242,7 @@ impl PublicKey {
             PublicKey::Ed25519(_) => ED25519.0,
             #[cfg(feature = "openssl")]
             PublicKey::RSA { ref hash, .. } => hash.name().0,
-            PublicKey::P256(_) => ECDSA_SHA2_NISTP256.0,
-            PublicKey::P521(_) => ECDSA_SHA2_NISTP521.0,
+            PublicKey::EC { ref key } => key.algorithm(),
         }
     }
 
@@ -277,58 +267,7 @@ impl PublicKey {
                 };
                 verify().unwrap_or(false)
             }
-            PublicKey::P256(ref public) => {
-                const FIELD_LEN: usize =
-                    <p256::NistP256 as p256::elliptic_curve::Curve>::FieldBytesSize::USIZE;
-                let mut reader = sig.reader(0);
-                let mut read_field = || -> Option<p256::FieldBytes> {
-                    let f = reader.read_mpint().ok()?;
-                    let f = f.strip_prefix(&[0]).unwrap_or(f);
-                    let mut result = [0; FIELD_LEN];
-                    if f.len() > FIELD_LEN {
-                        return None;
-                    }
-                    #[allow(clippy::indexing_slicing)] // length is known
-                    result[FIELD_LEN - f.len()..].copy_from_slice(f);
-                    Some(result.into())
-                };
-                let Some(r) = read_field() else { return false };
-                let Some(s) = read_field() else { return false };
-                let Ok(signature) = p256::ecdsa::Signature::from_scalars(r, s) else {
-                    return false;
-                };
-                p256::ecdsa::VerifyingKey::from(public)
-                    .verify(buffer, &signature)
-                    .is_ok()
-            }
-            PublicKey::P521(ref public) => {
-                const FIELD_LEN: usize =
-                    <p521::NistP521 as p256::elliptic_curve::Curve>::FieldBytesSize::USIZE;
-                let mut reader = sig.reader(0);
-                let mut read_field = || -> Option<p521::FieldBytes> {
-                    let f = reader.read_mpint().ok()?;
-                    let f = f.strip_prefix(&[0]).unwrap_or(f);
-                    let mut result = [0; FIELD_LEN];
-                    if f.len() > FIELD_LEN {
-                        return None;
-                    }
-                    #[allow(clippy::indexing_slicing)] // length is known
-                    result[FIELD_LEN - f.len()..].copy_from_slice(f);
-                    Some(GenericArray::clone_from_slice(&result))
-                };
-                let Some(r) = read_field() else { return false };
-                let Some(s) = read_field() else { return false };
-                let Ok(signature) = p521::ecdsa::Signature::from_scalars(r, s) else {
-                    return false;
-                };
-
-                // Length known
-                #[allow(clippy::unwrap_used)]
-                p521::ecdsa::VerifyingKey::from_sec1_bytes(&public.to_sec1_bytes())
-                    .unwrap()
-                    .verify(buffer, &signature)
-                    .is_ok()
-            }
+            PublicKey::EC { ref key, .. } => ec_verify(key, buffer, sig).is_ok(),
         }
     }
 
@@ -377,6 +316,9 @@ pub enum KeyPair {
         key: openssl::rsa::Rsa<Private>,
         hash: SignatureHash,
     },
+    EC {
+        key: ec::PrivateKey,
+    },
 }
 
 impl Clone for KeyPair {
@@ -391,6 +333,7 @@ impl Clone for KeyPair {
                 key: key.clone(),
                 hash: *hash,
             },
+            Self::EC { key } => Self::EC { key: key.clone() },
         }
     }
 }
@@ -405,6 +348,7 @@ impl std::fmt::Debug for KeyPair {
             ),
             #[cfg(feature = "openssl")]
             KeyPair::RSA { .. } => write!(f, "RSA {{ (hidden) }}"),
+            KeyPair::EC { .. } => write!(f, "EC {{ (hidden) }}"),
         }
     }
 }
@@ -430,6 +374,9 @@ impl KeyPair {
                     hash: *hash,
                 }
             }
+            KeyPair::EC { ref key } => PublicKey::EC {
+                key: key.to_public_key(),
+            },
         })
     }
 
@@ -439,6 +386,7 @@ impl KeyPair {
             KeyPair::Ed25519(_) => ED25519.0,
             #[cfg(feature = "openssl")]
             KeyPair::RSA { ref hash, .. } => hash.name().0,
+            KeyPair::EC { ref key } => key.algorithm(),
         }
     }
 
@@ -470,6 +418,10 @@ impl KeyPair {
                 bytes: rsa_signature(hash, key, to_sign)?,
                 hash: *hash,
             }),
+            KeyPair::EC { ref key } => Ok(Signature::ECDSA {
+                algorithm: key.algorithm(),
+                signature: ec_signature(key, to_sign)?,
+            }),
         }
     }
 
@@ -499,6 +451,13 @@ impl KeyPair {
                 buffer.extend_ssh_string(name.0.as_bytes());
                 buffer.extend_ssh_string(&signature);
             }
+            KeyPair::EC { ref key } => {
+                let algorithm = key.algorithm().as_bytes();
+                let signature = ec_signature(key, to_sign.as_ref())?;
+                buffer.push_u32_be((algorithm.len() + signature.len() + 8) as u32);
+                buffer.extend_ssh_string(algorithm);
+                buffer.extend_ssh_string(&signature);
+            }
         }
         Ok(())
     }
@@ -524,6 +483,13 @@ impl KeyPair {
                 buffer.extend_ssh_string(name.0.as_bytes());
                 buffer.extend_ssh_string(&signature);
             }
+            KeyPair::EC { ref key } => {
+                let signature = ec_signature(key, buffer)?;
+                let algorithm = key.algorithm().as_bytes();
+                buffer.push_u32_be((algorithm.len() + signature.len() + 8) as u32);
+                buffer.extend_ssh_string(algorithm);
+                buffer.extend_ssh_string(&signature);
+            }
         }
         Ok(())
     }
@@ -538,6 +504,7 @@ impl KeyPair {
                 key: key.clone(),
                 hash,
             }),
+            KeyPair::EC { .. } => None,
         }
     }
 }
@@ -564,6 +531,19 @@ fn rsa_signature(
     let mut signer = Signer::new(hash.message_digest(), &pkey)?;
     signer.update(b)?;
     Ok(signer.sign_to_vec()?)
+}
+
+fn ec_signature(key: &ec::PrivateKey, b: &[u8]) -> Result<Vec<u8>, Error> {
+    let (r, s) = key.try_sign(b)?;
+    let mut buf = Vec::new();
+    buf.extend_ssh_mpint(&r);
+    buf.extend_ssh_mpint(&s);
+    Ok(buf)
+}
+
+fn ec_verify(key: &ec::PublicKey, b: &[u8], sig: &[u8]) -> Result<(), Error> {
+    let mut reader = sig.reader(0);
+    key.verify(b, reader.read_mpint()?, reader.read_mpint()?)
 }
 
 /// Parse a public key from a byte slice.
@@ -599,21 +579,22 @@ pub fn parse_public_key(
             });
         }
     }
-    if t == b"ecdsa-sha2-nistp256" {
-        if pos.read_string()? != b"nistp256" {
+    if t == crate::KEYTYPE_ECDSA_SHA2_NISTP256
+        || t == crate::KEYTYPE_ECDSA_SHA2_NISTP384
+        || t == crate::KEYTYPE_ECDSA_SHA2_NISTP521
+    {
+        let ident = pos.read_string()?;
+        let sec1_bytes = pos.read_string()?;
+        let key = ec::PublicKey::from_sec1_bytes(t, sec1_bytes)?;
+        if ident != key.ident().as_bytes() {
             return Err(Error::CouldNotReadKey);
         }
-        let sec1_bytes = pos.read_string()?;
-        let key = p256::PublicKey::from_sec1_bytes(sec1_bytes)?;
-        return Ok(PublicKey::P256(key));
-    }
-    if t == b"ecdsa-sha2-nistp521" {
-        if pos.read_string()? != b"nistp521" {
-            return Err(Error::CouldNotReadKey);
-        }
-        let sec1_bytes = pos.read_string()?;
-        let key = p521::PublicKey::from_sec1_bytes(sec1_bytes)?;
-        return Ok(PublicKey::P521(key));
+        return Ok(PublicKey::EC { key });
     }
     Err(Error::CouldNotReadKey)
+}
+
+/// Obtain a cryptographic-safe random number generator.
+pub fn safe_rng() -> impl rand::CryptoRng + rand::RngCore {
+    rand::thread_rng()
 }

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -14,7 +14,7 @@
 //! to do all these in a single example: start and SSH agent server,
 //! connect to it with a client, decipher an encrypted private key
 //! (the password is `b"blabla"`), send it to the agent, and ask the
-//! agent to sign a piece of data (`b"Please sign this", below).
+//! agent to sign a piece of data (`b"Please sign this"`, below).
 //!
 //!```
 //! use russh_keys::*;

--- a/russh/src/key.rs
+++ b/russh/src/key.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 //
 use russh_cryptovec::CryptoVec;
+use russh_keys::ec;
 use russh_keys::encoding::*;
 use russh_keys::key::*;
-use russh_keys::PublicKeyBase64;
 
 #[doc(hidden)]
 pub trait PubKey {
@@ -30,9 +30,6 @@ impl PubKey for PublicKey {
                 buffer.extend_ssh_string(ED25519.0.as_bytes());
                 buffer.extend_ssh_string(public.as_bytes());
             }
-            PublicKey::P256(_) | PublicKey::P521(_) => {
-                buffer.extend_ssh_string(&self.public_key_bytes());
-            }
             #[cfg(feature = "openssl")]
             PublicKey::RSA { ref key, .. } => {
                 #[allow(clippy::unwrap_used)] // type known
@@ -43,6 +40,9 @@ impl PubKey for PublicKey {
                 buffer.extend_ssh_string(SSH_RSA.0.as_bytes());
                 buffer.extend_ssh_mpint(&e);
                 buffer.extend_ssh_mpint(&n);
+            }
+            PublicKey::EC { ref key } => {
+                write_ec_public_key(buffer, key);
             }
         }
     }
@@ -66,6 +66,20 @@ impl PubKey for KeyPair {
                 buffer.extend_ssh_mpint(&e);
                 buffer.extend_ssh_mpint(&n);
             }
+            KeyPair::EC { ref key } => {
+                write_ec_public_key(buffer, &key.to_public_key());
+            }
         }
     }
+}
+
+pub fn write_ec_public_key(buf: &mut CryptoVec, key: &ec::PublicKey) {
+    let algorithm = key.algorithm().as_bytes();
+    let ident = key.ident().as_bytes();
+    let q = key.to_sec1_bytes();
+
+    buf.push_u32_be((algorithm.len() + ident.len() + q.len() + 12) as u32);
+    buf.extend_ssh_string(algorithm);
+    buf.extend_ssh_string(ident);
+    buf.extend_ssh_string(&q);
 }

--- a/russh/src/key.rs
+++ b/russh/src/key.rs
@@ -73,7 +73,7 @@ impl PubKey for KeyPair {
     }
 }
 
-pub fn write_ec_public_key(buf: &mut CryptoVec, key: &ec::PublicKey) {
+pub(crate) fn write_ec_public_key(buf: &mut CryptoVec, key: &ec::PublicKey) {
     let algorithm = key.algorithm().as_bytes();
     let ident = key.ident().as_bytes();
     let q = key.to_sec1_bytes();

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -139,18 +139,17 @@ impl Named for () {
     }
 }
 
+use russh_keys::key::ED25519;
 #[cfg(feature = "openssl")]
 use russh_keys::key::SSH_RSA;
-use russh_keys::key::{ECDSA_SHA2_NISTP256, ECDSA_SHA2_NISTP521, ED25519};
 
 impl Named for PublicKey {
     fn name(&self) -> &'static str {
         match self {
             PublicKey::Ed25519(_) => ED25519.0,
-            PublicKey::P256(_) => ECDSA_SHA2_NISTP256.0,
-            PublicKey::P521(_) => ECDSA_SHA2_NISTP521.0,
             #[cfg(feature = "openssl")]
             PublicKey::RSA { .. } => SSH_RSA.0,
+            PublicKey::EC { ref key } => key.algorithm(),
         }
     }
 }
@@ -161,6 +160,7 @@ impl Named for KeyPair {
             KeyPair::Ed25519 { .. } => ED25519.0,
             #[cfg(feature = "openssl")]
             KeyPair::RSA { ref hash, .. } => hash.name().0,
+            KeyPair::EC { ref key } => key.algorithm(),
         }
     }
 }


### PR DESCRIPTION
* Moved ECDSA into `ec` module.
* Added support and tests for these algorithms.

Ported and cleaned up from a different fork of thrussh by me.