### PR TITLE
Add pure-rust RSA implementation

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -39,6 +39,7 @@ ctr = "0.9"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder = "1.4"
 data-encoding = "2.3"
+digest = "0.10"
 dirs = "5.0"
 ecdsa = "0.16"
 ed25519-dalek = { version= "2.0", features = ["rand_core"] }
@@ -55,12 +56,14 @@ p256 = "0.13"
 p384 = "0.13"
 p521 = "0.13"
 pbkdf2 = "0.11"
+pkcs1 = "0.7"
 rand = "0.8"
 rand_core = { version = "0.6.4", features = ["std"] }
+rsa = "0.9"
 russh-cryptovec = { version = "0.7.0", path = "../cryptovec" }
 serde = { version = "1.0", features = ["derive"] }
-sha1 = "0.10"
-sha2 = "0.10"
+sha1 = { version = "0.10", features = ["oid"] }
+sha2 = { version = "0.10", features = ["oid"] }
 thiserror = "1.0"
 tokio = { version = "1.17.0", features = ["io-util", "rt-multi-thread", "time", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/russh-keys/src/agent/client.rs
+++ b/russh-keys/src/agent/client.rs
@@ -9,6 +9,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use super::{msg, Constraint};
 use crate::encoding::{Encoding, Reader};
 use crate::key::{PublicKey, SignatureHash};
+use crate::protocol;
 use crate::{key, Error, PublicKeyBase64};
 
 /// SSH agent client.
@@ -121,24 +122,11 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
                 self.buf.extend(pair.verifying_key().as_bytes());
                 self.buf.extend_ssh_string(b"");
             }
-            #[cfg(feature = "openssl")]
             #[allow(clippy::unwrap_used)] // key is known to be private
             key::KeyPair::RSA { ref key, .. } => {
                 self.buf.extend_ssh_string(b"ssh-rsa");
-                self.buf.extend_ssh_mpint(&key.n().to_vec());
-                self.buf.extend_ssh_mpint(&key.e().to_vec());
-                self.buf.extend_ssh_mpint(&key.d().to_vec());
-                if let Some(iqmp) = key.iqmp() {
-                    self.buf.extend_ssh_mpint(&iqmp.to_vec());
-                } else {
-                    let mut ctx = openssl::bn::BigNumContext::new()?;
-                    let mut iqmp = openssl::bn::BigNum::new()?;
-                    iqmp.mod_inverse(key.p().unwrap(), key.q().unwrap(), &mut ctx)?;
-                    self.buf.extend_ssh_mpint(&iqmp.to_vec());
-                }
-                self.buf.extend_ssh_mpint(&key.p().unwrap().to_vec());
-                self.buf.extend_ssh_mpint(&key.q().unwrap().to_vec());
-                self.buf.extend_ssh_string(b"");
+                self.buf
+                    .extend_ssh(&protocol::RsaPrivateKey::try_from(key)?);
             }
             key::KeyPair::EC { ref key } => {
                 self.buf.extend_ssh_string(key.algorithm().as_bytes());
@@ -267,21 +255,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
                 let t = r.read_string()?;
                 debug!("t = {:?}", std::str::from_utf8(t));
                 match t {
-                    #[cfg(feature = "openssl")]
-                    b"ssh-rsa" => {
-                        let e = r.read_mpint()?;
-                        let n = r.read_mpint()?;
-                        use openssl::bn::BigNum;
-                        use openssl::pkey::PKey;
-                        use openssl::rsa::Rsa;
-                        keys.push(PublicKey::RSA {
-                            key: key::OpenSSLPKey(PKey::from_rsa(Rsa::from_public_components(
-                                BigNum::from_slice(n)?,
-                                BigNum::from_slice(e)?,
-                            )?)?),
-                            hash: SignatureHash::SHA2_512,
-                        })
-                    }
+                    b"ssh-rsa" => keys.push(key::PublicKey::new_rsa_with_hash(
+                        &r.read_ssh()?,
+                        SignatureHash::SHA2_512,
+                    )?),
                     b"ssh-ed25519" => keys.push(PublicKey::Ed25519(
                         ed25519_dalek::VerifyingKey::try_from(r.read_string()?)?,
                     )),
@@ -351,7 +328,6 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
         self.buf.extend_ssh_string(data);
         debug!("public = {:?}", public);
         let hash = match public {
-            #[cfg(feature = "openssl")]
             PublicKey::RSA { hash, .. } => match hash {
                 SignatureHash::SHA2_256 => 2,
                 SignatureHash::SHA2_512 => 4,
@@ -534,14 +510,11 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AgentClient<S> {
 
 fn key_blob(public: &key::PublicKey, buf: &mut CryptoVec) -> Result<(), Error> {
     match *public {
-        #[cfg(feature = "openssl")]
         PublicKey::RSA { ref key, .. } => {
             buf.extend(&[0, 0, 0, 0]);
             let len0 = buf.len();
             buf.extend_ssh_string(b"ssh-rsa");
-            let rsa = key.0.rsa()?;
-            buf.extend_ssh_mpint(&rsa.e().to_vec());
-            buf.extend_ssh_mpint(&rsa.n().to_vec());
+            buf.extend_ssh(&protocol::RsaPublicKey::from(key));
             let len1 = buf.len();
             #[allow(clippy::indexing_slicing)] // length is known
             BigEndian::write_u32(&mut buf[5..], (len1 - len0) as u32);

--- a/russh-keys/src/backend_openssl.rs
+++ b/russh-keys/src/backend_openssl.rs
@@ -1,0 +1,210 @@
+use std::convert::TryFrom;
+
+use crate::key::{RsaCrtExtra, SignatureHash};
+use crate::{protocol, Error};
+use openssl::{
+    bn::{BigNum, BigNumContext, BigNumRef},
+    hash::MessageDigest,
+    pkey::{PKey, Private, Public},
+    rsa::Rsa,
+};
+
+#[derive(Clone)]
+pub struct RsaPublic {
+    key: Rsa<Public>,
+    pkey: PKey<Public>,
+}
+
+impl RsaPublic {
+    pub fn verify_detached(&self, hash: &SignatureHash, msg: &[u8], sig: &[u8]) -> bool {
+        openssl::sign::Verifier::new(message_digest_for(hash), &self.pkey)
+            .and_then(|mut v| v.verify_oneshot(sig, msg))
+            .unwrap_or(false)
+    }
+}
+
+impl TryFrom<&protocol::RsaPublicKey<'_>> for RsaPublic {
+    type Error = Error;
+
+    fn try_from(pk: &protocol::RsaPublicKey<'_>) -> Result<Self, Self::Error> {
+        let key = Rsa::from_public_components(
+            BigNum::from_slice(&pk.modulus)?,
+            BigNum::from_slice(&pk.public_exponent)?,
+        )?;
+        Ok(Self {
+            pkey: PKey::from_rsa(key.clone())?,
+            key,
+        })
+    }
+}
+
+impl<'a> From<&RsaPublic> for protocol::RsaPublicKey<'a> {
+    fn from(key: &RsaPublic) -> Self {
+        Self {
+            modulus: key.key.n().to_vec().into(),
+            public_exponent: key.key.e().to_vec().into(),
+        }
+    }
+}
+
+impl PartialEq for RsaPublic {
+    fn eq(&self, b: &RsaPublic) -> bool {
+        self.pkey.public_eq(&b.pkey)
+    }
+}
+
+impl Eq for RsaPublic {}
+
+impl std::fmt::Debug for RsaPublic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "RsaPublic {{ (hidden) }}")
+    }
+}
+
+#[derive(Clone)]
+pub struct RsaPrivate {
+    key: Rsa<Private>,
+    pkey: PKey<Private>,
+}
+
+impl RsaPrivate {
+    pub fn new(
+        sk: &protocol::RsaPrivateKey<'_>,
+        extra: Option<&RsaCrtExtra<'_>>,
+    ) -> Result<Self, Error> {
+        let (d, p, q) = (
+            BigNum::from_slice(&sk.private_exponent)?,
+            BigNum::from_slice(&sk.prime1)?,
+            BigNum::from_slice(&sk.prime2)?,
+        );
+        let (dp, dq) = if let Some(extra) = extra {
+            (
+                BigNum::from_slice(&extra.dp)?,
+                BigNum::from_slice(&extra.dq)?,
+            )
+        } else {
+            calc_dp_dq(d.as_ref(), p.as_ref(), q.as_ref())?
+        };
+        let key = Rsa::from_private_components(
+            BigNum::from_slice(&sk.public_key.modulus)?,
+            BigNum::from_slice(&sk.public_key.public_exponent)?,
+            d,
+            p,
+            q,
+            dp,
+            dq,
+            BigNum::from_slice(&sk.coefficient)?,
+        )?;
+        key.check_key()?;
+        Ok(Self {
+            pkey: PKey::from_rsa(key.clone())?,
+            key,
+        })
+    }
+
+    pub fn new_from_der(der: &[u8]) -> Result<Self, Error> {
+        let key = Rsa::private_key_from_der(der)?;
+        key.check_key()?;
+        Ok(Self {
+            pkey: PKey::from_rsa(key.clone())?,
+            key,
+        })
+    }
+
+    pub fn generate(bits: usize) -> Result<Self, Error> {
+        let key = Rsa::generate(bits as u32)?;
+        Ok(Self {
+            pkey: PKey::from_rsa(key.clone())?,
+            key,
+        })
+    }
+
+    pub fn sign(&self, hash: &SignatureHash, msg: &[u8]) -> Result<Vec<u8>, Error> {
+        Ok(
+            openssl::sign::Signer::new(message_digest_for(hash), &self.pkey)?
+                .sign_oneshot_to_vec(msg)?,
+        )
+    }
+}
+
+impl<'a> TryFrom<&RsaPrivate> for protocol::RsaPrivateKey<'a> {
+    type Error = Error;
+
+    fn try_from(key: &RsaPrivate) -> Result<protocol::RsaPrivateKey<'a>, Self::Error> {
+        let key = &key.key;
+        // We always set these.
+        if let (Some(p), Some(q), Some(iqmp)) = (key.p(), key.q(), key.iqmp()) {
+            Ok(protocol::RsaPrivateKey {
+                public_key: protocol::RsaPublicKey {
+                    modulus: key.n().to_vec().into(),
+                    public_exponent: key.e().to_vec().into(),
+                },
+                private_exponent: key.d().to_vec().into(),
+                prime1: p.to_vec().into(),
+                prime2: q.to_vec().into(),
+                coefficient: iqmp.to_vec().into(),
+                comment: b"".as_slice().into(),
+            })
+        } else {
+            Err(Error::KeyIsCorrupt)
+        }
+    }
+}
+
+impl<'a> TryFrom<&RsaPrivate> for RsaCrtExtra<'a> {
+    type Error = Error;
+
+    fn try_from(key: &RsaPrivate) -> Result<RsaCrtExtra<'a>, Self::Error> {
+        let key = &key.key;
+        // We always set these.
+        if let (Some(dp), Some(dq)) = (key.dmp1(), key.dmq1()) {
+            Ok(RsaCrtExtra {
+                dp: dp.to_vec().into(),
+                dq: dq.to_vec().into(),
+            })
+        } else {
+            Err(Error::KeyIsCorrupt)
+        }
+    }
+}
+
+impl<'a> From<&RsaPrivate> for protocol::RsaPublicKey<'a> {
+    fn from(key: &RsaPrivate) -> Self {
+        Self {
+            modulus: key.key.n().to_vec().into(),
+            public_exponent: key.key.e().to_vec().into(),
+        }
+    }
+}
+
+impl TryFrom<&RsaPrivate> for RsaPublic {
+    type Error = Error;
+
+    fn try_from(key: &RsaPrivate) -> Result<Self, Self::Error> {
+        let key = Rsa::from_public_components(key.key.n().to_owned()?, key.key.e().to_owned()?)?;
+        Ok(Self {
+            pkey: PKey::from_rsa(key.clone())?,
+            key,
+        })
+    }
+}
+
+fn message_digest_for(hash: &SignatureHash) -> MessageDigest {
+    match hash {
+        SignatureHash::SHA2_256 => MessageDigest::sha256(),
+        SignatureHash::SHA2_512 => MessageDigest::sha512(),
+        SignatureHash::SHA1 => MessageDigest::sha1(),
+    }
+}
+
+fn calc_dp_dq(d: &BigNumRef, p: &BigNumRef, q: &BigNumRef) -> Result<(BigNum, BigNum), Error> {
+    let one = BigNum::from_u32(1)?;
+    let p1 = p - one.as_ref();
+    let q1 = q - one.as_ref();
+    let mut context = BigNumContext::new()?;
+    let mut dp = BigNum::new()?;
+    let mut dq = BigNum::new()?;
+    dp.checked_rem(d, &p1, &mut context)?;
+    dq.checked_rem(d, &q1, &mut context)?;
+    Ok((dp, dq))
+}

--- a/russh-keys/src/backend_rust.rs
+++ b/russh-keys/src/backend_rust.rs
@@ -1,0 +1,185 @@
+use std::convert::TryFrom;
+
+use crate::key::{RsaCrtExtra, SignatureHash};
+use crate::{protocol, Error};
+use rsa::{
+    traits::{PrivateKeyParts, PublicKeyParts},
+    BigUint,
+};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct RsaPublic {
+    key: rsa::RsaPublicKey,
+}
+
+impl RsaPublic {
+    pub fn verify_detached(&self, hash: &SignatureHash, msg: &[u8], sig: &[u8]) -> bool {
+        self.key
+            .verify(signature_scheme_for_hash(hash), &hash_msg(hash, msg), sig)
+            .is_ok()
+    }
+}
+
+impl TryFrom<&protocol::RsaPublicKey<'_>> for RsaPublic {
+    type Error = Error;
+
+    fn try_from(pk: &protocol::RsaPublicKey<'_>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key: rsa::RsaPublicKey::new(
+                BigUint::from_bytes_be(&pk.modulus),
+                BigUint::from_bytes_be(&pk.public_exponent),
+            )?,
+        })
+    }
+}
+
+impl<'a> From<&RsaPublic> for protocol::RsaPublicKey<'a> {
+    fn from(key: &RsaPublic) -> Self {
+        Self {
+            modulus: key.key.n().to_bytes_be().into(),
+            public_exponent: key.key.e().to_bytes_be().into(),
+        }
+    }
+}
+
+impl std::fmt::Debug for RsaPublic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "RsaPublic {{ (hidden) }}")
+    }
+}
+
+#[derive(Clone)]
+pub struct RsaPrivate {
+    key: rsa::RsaPrivateKey,
+}
+
+impl RsaPrivate {
+    pub fn new(
+        sk: &protocol::RsaPrivateKey<'_>,
+        extra: Option<&RsaCrtExtra<'_>>,
+    ) -> Result<Self, Error> {
+        let mut key = rsa::RsaPrivateKey::from_components(
+            BigUint::from_bytes_be(&sk.public_key.modulus),
+            BigUint::from_bytes_be(&sk.public_key.public_exponent),
+            BigUint::from_bytes_be(&sk.private_exponent),
+            vec![
+                BigUint::from_bytes_be(&sk.prime1),
+                BigUint::from_bytes_be(&sk.prime2),
+            ],
+        )?;
+        key.validate()?;
+        key.precompute()?;
+
+        if Some(BigUint::from_bytes_be(&sk.coefficient)) != key.crt_coefficient() {
+            return Err(Error::KeyIsCorrupt);
+        }
+        if let Some(extra) = extra {
+            if (
+                Some(&BigUint::from_bytes_be(&extra.dp)),
+                Some(&BigUint::from_bytes_be(&extra.dq)),
+            ) != (key.dp(), key.dq())
+            {
+                return Err(Error::KeyIsCorrupt);
+            }
+        }
+
+        Ok(Self { key })
+    }
+
+    pub fn new_from_der(der: &[u8]) -> Result<Self, Error> {
+        use pkcs1::DecodeRsaPrivateKey;
+        Ok(Self {
+            key: rsa::RsaPrivateKey::from_pkcs1_der(der)?,
+        })
+    }
+
+    pub fn generate(bits: usize) -> Result<Self, Error> {
+        Ok(Self {
+            key: rsa::RsaPrivateKey::new(&mut crate::key::safe_rng(), bits)?,
+        })
+    }
+
+    pub fn sign(&self, hash: &SignatureHash, msg: &[u8]) -> Result<Vec<u8>, Error> {
+        Ok(self
+            .key
+            .sign(signature_scheme_for_hash(hash), &hash_msg(hash, msg))?)
+    }
+}
+
+impl<'a> TryFrom<&RsaPrivate> for protocol::RsaPrivateKey<'a> {
+    type Error = Error;
+
+    fn try_from(key: &RsaPrivate) -> Result<protocol::RsaPrivateKey<'a>, Self::Error> {
+        let key = &key.key;
+        // We always precompute these.
+        if let ([p, q], Some(iqmp)) = (key.primes(), key.crt_coefficient()) {
+            Ok(protocol::RsaPrivateKey {
+                public_key: protocol::RsaPublicKey {
+                    modulus: key.n().to_bytes_be().into(),
+                    public_exponent: key.e().to_bytes_be().into(),
+                },
+                private_exponent: key.d().to_bytes_be().into(),
+                prime1: p.to_bytes_be().into(),
+                prime2: q.to_bytes_be().into(),
+                coefficient: iqmp.to_bytes_be().into(),
+                comment: b"".as_slice().into(),
+            })
+        } else {
+            Err(Error::KeyIsCorrupt)
+        }
+    }
+}
+
+impl<'a> TryFrom<&RsaPrivate> for RsaCrtExtra<'a> {
+    type Error = Error;
+
+    fn try_from(key: &RsaPrivate) -> Result<RsaCrtExtra<'a>, Self::Error> {
+        let key = &key.key;
+        // We always precompute these.
+        if let (Some(dp), Some(dq)) = (key.dp(), key.dq()) {
+            Ok(RsaCrtExtra {
+                dp: dp.to_bytes_be().into(),
+                dq: dq.to_bytes_be().into(),
+            })
+        } else {
+            Err(Error::KeyIsCorrupt)
+        }
+    }
+}
+
+impl<'a> From<&RsaPrivate> for protocol::RsaPublicKey<'a> {
+    fn from(key: &RsaPrivate) -> Self {
+        Self {
+            modulus: key.key.n().to_bytes_be().into(),
+            public_exponent: key.key.e().to_bytes_be().into(),
+        }
+    }
+}
+
+impl TryFrom<&RsaPrivate> for RsaPublic {
+    type Error = Error;
+
+    fn try_from(key: &RsaPrivate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key: key.key.to_public_key(),
+        })
+    }
+}
+
+fn signature_scheme_for_hash(hash: &SignatureHash) -> rsa::pkcs1v15::Pkcs1v15Sign {
+    use rsa::pkcs1v15::Pkcs1v15Sign;
+    match *hash {
+        SignatureHash::SHA2_256 => Pkcs1v15Sign::new::<sha2::Sha256>(),
+        SignatureHash::SHA2_512 => Pkcs1v15Sign::new::<sha2::Sha512>(),
+        SignatureHash::SHA1 => Pkcs1v15Sign::new::<sha1::Sha1>(),
+    }
+}
+
+fn hash_msg(hash: &SignatureHash, msg: &[u8]) -> Vec<u8> {
+    use digest::Digest;
+    match *hash {
+        SignatureHash::SHA2_256 => sha2::Sha256::digest(msg).to_vec(),
+        SignatureHash::SHA2_512 => sha2::Sha512::digest(msg).to_vec(),
+        SignatureHash::SHA1 => sha1::Sha1::digest(msg).to_vec(),
+    }
+}

--- a/russh-keys/src/encoding.rs
+++ b/russh-keys/src/encoding.rs
@@ -41,6 +41,20 @@ pub trait Encoding {
     fn extend_list<A: Bytes, I: Iterator<Item = A>>(&mut self, list: I);
     /// Push an SSH-encoded empty list.
     fn write_empty_list(&mut self);
+    /// Push an SSH-encoded value.
+    fn extend_ssh<T: SshWrite>(&mut self, v: &T) {
+        v.write_ssh(self)
+    }
+    /// Push a nested SSH-encoded value.
+    fn extend_wrapped<F>(&mut self, write: F)
+    where
+        F: FnOnce(&mut Self);
+}
+
+/// Trait for writing value in SSH-encoded format.
+pub trait SshWrite {
+    /// Write the value.
+    fn write_ssh<E: Encoding + ?Sized>(&self, encoder: &mut E);
 }
 
 /// Encoding length of the given mpint.
@@ -109,6 +123,20 @@ impl Encoding for Vec<u8> {
     fn write_empty_list(&mut self) {
         self.extend([0, 0, 0, 0]);
     }
+
+    fn extend_wrapped<F>(&mut self, write: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        let len_offset = self.len();
+        #[allow(clippy::unwrap_used)] // writing into Vec<> can't panic
+        self.write_u32::<BigEndian>(0).unwrap();
+        let data_offset = self.len();
+        write(self);
+        let data_len = self.len() - data_offset;
+        #[allow(clippy::indexing_slicing)] // length is known
+        BigEndian::write_u32(&mut self[len_offset..], data_len as u32);
+    }
 }
 
 impl Encoding for CryptoVec {
@@ -162,6 +190,19 @@ impl Encoding for CryptoVec {
 
     fn write_empty_list(&mut self) {
         self.extend(&[0, 0, 0, 0]);
+    }
+
+    fn extend_wrapped<F>(&mut self, write: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        let len_offset = self.len();
+        self.push_u32_be(0);
+        let data_offset = self.len();
+        write(self);
+        let data_len = self.len() - data_offset;
+        #[allow(clippy::indexing_slicing)] // length is known
+        BigEndian::write_u32(&mut self[len_offset..], data_len as u32);
     }
 }
 
@@ -244,4 +285,14 @@ impl<'a> Position<'a> {
             Err(Error::IndexOutOfBounds)
         }
     }
+
+    pub fn read_ssh<T: SshRead<'a>>(&mut self) -> Result<T, Error> {
+        T::read_ssh(self)
+    }
+}
+
+/// Trait for reading value in SSH-encoded format.
+pub trait SshRead<'a>: Sized + 'a {
+    /// Read the value from a position.
+    fn read_ssh(pos: &mut Position<'a>) -> Result<Self, Error>;
 }

--- a/russh-keys/src/format/pkcs5.rs
+++ b/russh-keys/src/format/pkcs5.rs
@@ -5,7 +5,6 @@ use crate::{key, Error};
 
 /// Decode a secret key in the PKCS#5 format, possibly deciphering it
 /// using the supplied password.
-#[cfg(feature = "openssl")]
 pub fn decode_pkcs5(
     secret: &[u8],
     password: Option<&str>,

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -10,11 +10,11 @@
 //! opening key files, deciphering encrypted keys, and dealing with
 //! agents.
 //!
-//! The following example (which uses the `openssl` feature) shows how
-//! to do all these in a single example: start and SSH agent server,
-//! connect to it with a client, decipher an encrypted private key
-//! (the password is `b"blabla"`), send it to the agent, and ask the
-//! agent to sign a piece of data (`b"Please sign this"`, below).
+//! The following example shows how to do all these in a single example:
+//! start and SSH agent server, connect to it with a client, decipher
+//! an encrypted private key (the password is `b"blabla"`), send it to
+//! the agent, and ask the agent to sign a piece of data
+//! (`b"Please sign this"`, below).
 //!
 //!```
 //! use russh_keys::*;
@@ -30,7 +30,7 @@
 //!
 //! const PKCS8_ENCRYPTED: &'static str = "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIFLTBXBgkqhkiG9w0BBQ0wSjApBgkqhkiG9w0BBQwwHAQITo1O0b8YrS0CAggA\nMAwGCCqGSIb3DQIJBQAwHQYJYIZIAWUDBAEqBBBtLH4T1KOfo1GGr7salhR8BIIE\n0KN9ednYwcTGSX3hg7fROhTw7JAJ1D4IdT1fsoGeNu2BFuIgF3cthGHe6S5zceI2\nMpkfwvHbsOlDFWMUIAb/VY8/iYxhNmd5J6NStMYRC9NC0fVzOmrJqE1wITqxtORx\nIkzqkgFUbaaiFFQPepsh5CvQfAgGEWV329SsTOKIgyTj97RxfZIKA+TR5J5g2dJY\nj346SvHhSxJ4Jc0asccgMb0HGh9UUDzDSql0OIdbnZW5KzYJPOx+aDqnpbz7UzY/\nP8N0w/pEiGmkdkNyvGsdttcjFpOWlLnLDhtLx8dDwi/sbEYHtpMzsYC9jPn3hnds\nTcotqjoSZ31O6rJD4z18FOQb4iZs3MohwEdDd9XKblTfYKM62aQJWH6cVQcg+1C7\njX9l2wmyK26Tkkl5Qg/qSfzrCveke5muZgZkFwL0GCcgPJ8RixSB4GOdSMa/hAMU\nkvFAtoV2GluIgmSe1pG5cNMhurxM1dPPf4WnD+9hkFFSsMkTAuxDZIdDk3FA8zof\nYhv0ZTfvT6V+vgH3Hv7Tqcxomy5Qr3tj5vvAqqDU6k7fC4FvkxDh2mG5ovWvc4Nb\nXv8sed0LGpYitIOMldu6650LoZAqJVv5N4cAA2Edqldf7S2Iz1QnA/usXkQd4tLa\nZ80+sDNv9eCVkfaJ6kOVLk/ghLdXWJYRLenfQZtVUXrPkaPpNXgD0dlaTN8KuvML\nUw/UGa+4ybnPsdVflI0YkJKbxouhp4iB4S5ACAwqHVmsH5GRnujf10qLoS7RjDAl\no/wSHxdT9BECp7TT8ID65u2mlJvH13iJbktPczGXt07nBiBse6OxsClfBtHkRLzE\nQF6UMEXsJnIIMRfrZQnduC8FUOkfPOSXc8r9SeZ3GhfbV/DmWZvFPCpjzKYPsM5+\nN8Bw/iZ7NIH4xzNOgwdp5BzjH9hRtCt4sUKVVlWfEDtTnkHNOusQGKu7HkBF87YZ\nRN/Nd3gvHob668JOcGchcOzcsqsgzhGMD8+G9T9oZkFCYtwUXQU2XjMN0R4VtQgZ\nrAxWyQau9xXMGyDC67gQ5xSn+oqMK0HmoW8jh2LG/cUowHFAkUxdzGadnjGhMOI2\nzwNJPIjF93eDF/+zW5E1l0iGdiYyHkJbWSvcCuvTwma9FIDB45vOh5mSR+YjjSM5\nnq3THSWNi7Cxqz12Q1+i9pz92T2myYKBBtu1WDh+2KOn5DUkfEadY5SsIu/Rb7ub\n5FBihk2RN3y/iZk+36I69HgGg1OElYjps3D+A9AjVby10zxxLAz8U28YqJZm4wA/\nT0HLxBiVw+rsHmLP79KvsT2+b4Diqih+VTXouPWC/W+lELYKSlqnJCat77IxgM9e\nYIhzD47OgWl33GJ/R10+RDoDvY4koYE+V5NLglEhbwjloo9Ryv5ywBJNS7mfXMsK\n/uf+l2AscZTZ1mhtL38efTQCIRjyFHc3V31DI0UdETADi+/Omz+bXu0D5VvX+7c6\nb1iVZKpJw8KUjzeUV8yOZhvGu3LrQbhkTPVYL555iP1KN0Eya88ra+FUKMwLgjYr\nJkUx4iad4dTsGPodwEP/Y9oX/Qk3ZQr+REZ8lg6IBoKKqqrQeBJ9gkm1jfKE6Xkc\nCog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux\n-----END ENCRYPTED PRIVATE KEY-----\n";
 //!
-//! #[cfg(all(unix, feature = "openssl"))]
+//! #[cfg(unix)]
 //! fn main() {
 //!    env_logger::try_init().unwrap_or(());
 //!    let dir = tempdir::TempDir::new("russh").unwrap();
@@ -58,7 +58,7 @@
 //!    }).unwrap()
 //! }
 //!
-//! #[cfg(any(not(unix), not(feature = "openssl")))]
+//! #[cfg(not(unix))]
 //! fn main() {}
 //!
 //! ```
@@ -80,10 +80,18 @@ use thiserror::Error;
 pub mod ec;
 pub mod encoding;
 pub mod key;
+pub mod protocol;
 pub mod signature;
 
 mod format;
 pub use format::*;
+
+#[cfg(feature = "openssl")]
+#[path = "backend_openssl.rs"]
+mod backend;
+#[cfg(not(feature = "openssl"))]
+#[path = "backend_rust.rs"]
+mod backend;
 
 /// A module to write SSH agent.
 pub mod agent;
@@ -139,6 +147,13 @@ pub enum Error {
     #[cfg(feature = "openssl")]
     #[error(transparent)]
     Openssl(#[from] openssl::error::ErrorStack),
+
+    #[cfg(not(feature = "openssl"))]
+    #[error("Rsa: {0}")]
+    Rsa(#[from] rsa::Error),
+    #[cfg(not(feature = "openssl"))]
+    #[error("Pkcs1: {0}")]
+    Pkcs1(#[from] pkcs1::Error),
 
     #[error(transparent)]
     Pad(#[from] PadError),
@@ -202,11 +217,7 @@ pub fn load_public_key<P: AsRef<Path>>(path: P) -> Result<key::PublicKey, Error>
 /// ```
 pub fn parse_public_key_base64(key: &str) -> Result<key::PublicKey, Error> {
     let base = BASE64_MIME.decode(key.as_bytes())?;
-    key::parse_public_key(
-        &base,
-        #[cfg(feature = "openssl")]
-        None,
-    )
+    key::parse_public_key(&base, None)
 }
 
 pub trait PublicKeyBase64 {
@@ -234,17 +245,13 @@ impl PublicKeyBase64 for key::PublicKey {
                     .unwrap();
                 s.extend_from_slice(publickey.as_bytes());
             }
-            #[cfg(feature = "openssl")]
             key::PublicKey::RSA { ref key, .. } => {
                 use encoding::Encoding;
                 let name = b"ssh-rsa";
                 #[allow(clippy::unwrap_used)] // Vec<>.write_all can't fail
                 s.write_u32::<BigEndian>(name.len() as u32).unwrap();
                 s.extend_from_slice(name);
-                #[allow(clippy::unwrap_used)] // TODO check
-                s.extend_ssh_mpint(&key.0.rsa().unwrap().e().to_vec());
-                #[allow(clippy::unwrap_used)] // TODO check
-                s.extend_ssh_mpint(&key.0.rsa().unwrap().n().to_vec());
+                s.extend_ssh(&protocol::RsaPublicKey::from(key));
             }
             key::PublicKey::EC { ref key } => {
                 write_ec_public_key(&mut s, key);
@@ -268,11 +275,9 @@ impl PublicKeyBase64 for key::KeyPair {
                 s.write_u32::<BigEndian>(public.len() as u32).unwrap();
                 s.extend_from_slice(public.as_slice());
             }
-            #[cfg(feature = "openssl")]
             key::KeyPair::RSA { ref key, .. } => {
                 use encoding::Encoding;
-                s.extend_ssh_mpint(&key.e().to_vec());
-                s.extend_ssh_mpint(&key.n().to_vec());
+                s.extend_ssh(&protocol::RsaPublicKey::from(key));
             }
             key::KeyPair::EC { ref key } => {
                 write_ec_public_key(&mut s, &key.to_public_key());
@@ -485,7 +490,7 @@ mod test {
     use std::fs::File;
     use std::io::Write;
 
-    #[cfg(all(unix, feature = "openssl"))]
+    #[cfg(unix)]
     use futures::Future;
 
     use super::*;
@@ -509,7 +514,6 @@ dP3jryYgvsCIBAA5jMWSjrmnOTXhidqcOy4xYCrAttzSnZ/cUadfBenL+DQq6neffw7j8r
 sJWR7W+cGvJ/vLsw==
 -----END OPENSSH PRIVATE KEY-----";
 
-    #[cfg(feature = "openssl")]
     const RSA_KEY: &str = "-----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
 NhAAAAAwEAAQAAAQEAuSvQ9m76zhRB4m0BUKPf17lwccj7KQ1Qtse63AOqP/VYItqEH8un
@@ -551,7 +555,6 @@ QR+u0AypRPmzHnOPAAAAEXJvb3RAMTQwOTExNTQ5NDBkAQ==
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_decode_rsa_secret_key() {
         env_logger::try_init().unwrap_or(());
         decode_secret_key(RSA_KEY, None).unwrap();
@@ -625,7 +628,6 @@ Ve0k2ddxoEsSE15H4lgNHM2iuYKzIqZJOReHRCTff6QGgMYPDqDfFfL1Hc1Ntql0pwAAAA
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_fingerprint() {
         let key = parse_public_key_base64(
             "AAAAC3NzaC1lZDI1NTE5AAAAILagOJFgwaMNhBWQINinKOXmqS4Gh5NgxgriXwdOoINJ",
@@ -727,7 +729,6 @@ Ve0k2ddxoEsSE15H4lgNHM2iuYKzIqZJOReHRCTff6QGgMYPDqDfFfL1Hc1Ntql0pwAAAA
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_srhb() {
         env_logger::try_init().unwrap_or(());
         let key = "AAAAB3NzaC1yc2EAAAADAQABAAACAQC0Xtz3tSNgbUQAXem4d+d6hMx7S8Nwm/DOO2AWyWCru+n/+jQ7wz2b5+3oG2+7GbWZNGj8HCc6wJSA3jUsgv1N6PImIWclD14qvoqY3Dea1J0CJgXnnM1xKzBz9C6pDHGvdtySg+yzEO41Xt4u7HFn4Zx5SGuI2NBsF5mtMLZXSi33jCIWVIkrJVd7sZaY8jiqeVZBB/UvkLPWewGVuSXZHT84pNw4+S0Rh6P6zdNutK+JbeuO+5Bav4h9iw4t2sdRkEiWg/AdMoSKmo97Gigq2mKdW12ivnXxz3VfxrCgYJj9WwaUUWSfnAju5SiNly0cTEAN4dJ7yB0mfLKope1kRhPsNaOuUmMUqlu/hBDM/luOCzNjyVJ+0LLB7SV5vOiV7xkVd4KbEGKou8eeCR3yjFazUe/D1pjYPssPL8cJhTSuMc+/UC9zD8yeEZhB9V+vW4NMUR+lh5+XeOzenl65lWYd/nBZXLBbpUMf1AOfbz65xluwCxr2D2lj46iApSIpvE63i3LzFkbGl9GdUiuZJLMFJzOWdhGGc97cB5OVyf8umZLqMHjaImxHEHrnPh1MOVpv87HYJtSBEsN4/omINCMZrk++CRYAIRKRpPKFWV7NQHcvw3m7XLR3KaTYe+0/MINIZwGdou9fLUU3zSd521vDjA/weasH0CyDHq7sZw==";
@@ -736,7 +737,6 @@ Ve0k2ddxoEsSE15H4lgNHM2iuYKzIqZJOReHRCTff6QGgMYPDqDfFfL1Hc1Ntql0pwAAAA
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_nikao() {
         env_logger::try_init().unwrap_or(());
         let key = "-----BEGIN RSA PRIVATE KEY-----
@@ -771,7 +771,6 @@ QaChXiDsryJZwsRnruvMRX9nedtqHrgnIsJLTXjppIhGhq5Kg4RQfOU=
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_decode_pkcs8_rsa_secret_key() {
         // Generated using: ssh-keygen -t rsa -b 1024 -m pkcs8 -f $file
         let key = "-----BEGIN PRIVATE KEY-----
@@ -971,7 +970,6 @@ ZgmnWhuwhyxErC5UkMHiEvTOZllxBvefs7XeJqL11pqQIHY4Gb5OQGiCNHiRRjg0egAAAA
         ecdsa_sign_verify(key, public);
     }
 
-    #[cfg(feature = "openssl")]
     pub const PKCS8_RSA: &str = "-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAwBGetHjW+3bDQpVktdemnk7JXgu1NBWUM+ysifYLDBvJ9ttX
 GNZSyQKA4v/dNr0FhAJ8I9BuOTjYCy1YfKylhl5D/DiSSXFPsQzERMmGgAlYvU2U
@@ -1002,7 +1000,6 @@ xV/JrzLAwPoKk3bkqys3bUmgo6DxVC/6RmMwPQ0rmpw78kOgEej90g==
 ";
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_loewenheim() -> Result<(), Error> {
         env_logger::try_init().unwrap_or(());
         let key = "-----BEGIN RSA PRIVATE KEY-----
@@ -1045,7 +1042,6 @@ KJaj7gc0n6gmKY6r0/Ddufy1JZ6eihBCSJ64RARBXeg2rZpyT+xxhMEZLK5meOeR
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_o01eg() {
         env_logger::try_init().unwrap_or(());
 
@@ -1083,14 +1079,12 @@ br8gXU8KyiY9sZVbmplRPF+ar462zcI2kt0a18mr0vbrdqp2eMjb37QDbVBJ+rPE
         decode_secret_key(key, Some("12345")).unwrap();
     }
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_pkcs8() {
         env_logger::try_init().unwrap_or(());
         println!("test");
         decode_secret_key(PKCS8_RSA, Some("blabla")).unwrap();
     }
 
-    #[cfg(feature = "openssl")]
     const PKCS8_ENCRYPTED: &str = "-----BEGIN ENCRYPTED PRIVATE KEY-----
 MIIFLTBXBgkqhkiG9w0BBQ0wSjApBgkqhkiG9w0BBQwwHAQITo1O0b8YrS0CAggA
 MAwGCCqGSIb3DQIJBQAwHQYJYIZIAWUDBAEqBBBtLH4T1KOfo1GGr7salhR8BIIE
@@ -1123,7 +1117,6 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
 -----END ENCRYPTED PRIVATE KEY-----";
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_gpg() {
         env_logger::try_init().unwrap_or(());
         let algo = [115, 115, 104, 45, 114, 115, 97];
@@ -1156,7 +1149,6 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
     fn test_pkcs8_encrypted() {
         env_logger::try_init().unwrap_or(());
         println!("test");
@@ -1199,7 +1191,6 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
                 assert!(public.verify_detached(a, sig));
             }
             key::KeyPair::EC { .. } => {}
-            #[cfg(feature = "openssl")]
             _ => {}
         }
 
@@ -1217,14 +1208,14 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
     }
 
     #[tokio::test]
-    #[cfg(all(unix, feature = "openssl"))]
+    #[cfg(unix)]
     async fn test_client_agent_rsa() {
         let key = decode_secret_key(PKCS8_ENCRYPTED, Some("blabla")).unwrap();
         test_client_agent(key).await.expect("ssh-agent test failed")
     }
 
     #[tokio::test]
-    #[cfg(all(unix, feature = "openssl"))]
+    #[cfg(unix)]
     async fn test_client_agent_openssh_rsa() {
         let key = decode_secret_key(RSA_KEY, None).unwrap();
         test_client_agent(key).await.expect("ssh-agent test failed")
@@ -1232,7 +1223,6 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
 
     #[test]
     #[cfg(unix)]
-    #[cfg(feature = "openssl")]
     fn test_agent() {
         env_logger::try_init().unwrap_or(());
         let dir = tempdir::TempDir::new("russh").unwrap();

--- a/russh-keys/src/protocol.rs
+++ b/russh-keys/src/protocol.rs
@@ -1,0 +1,74 @@
+use crate::encoding::{Encoding, Position, SshRead, SshWrite};
+use std::borrow::Cow;
+
+type Result<T> = std::result::Result<T, crate::Error>;
+
+/// SSH RSA public key.
+pub struct RsaPublicKey<'a> {
+    /// `e`: RSA public exponent.
+    pub public_exponent: Cow<'a, [u8]>,
+    /// `n`: RSA modulus.
+    pub modulus: Cow<'a, [u8]>,
+}
+
+impl<'a> SshRead<'a> for RsaPublicKey<'a> {
+    fn read_ssh(pos: &mut Position<'a>) -> Result<Self> {
+        Ok(Self {
+            public_exponent: Cow::Borrowed(pos.read_mpint()?),
+            modulus: Cow::Borrowed(pos.read_mpint()?),
+        })
+    }
+}
+
+impl SshWrite for RsaPublicKey<'_> {
+    fn write_ssh<E: Encoding + ?Sized>(&self, encoder: &mut E) {
+        encoder.extend_ssh_mpint(&self.public_exponent);
+        encoder.extend_ssh_mpint(&self.modulus);
+    }
+}
+
+/// SSH RSA private key.
+pub struct RsaPrivateKey<'a> {
+    /// RSA public key.
+    pub public_key: RsaPublicKey<'a>,
+    /// `d`: RSA private exponent.
+    pub private_exponent: Cow<'a, [u8]>,
+    /// CRT coefficient: `(inverse of q) mod p`.
+    pub coefficient: Cow<'a, [u8]>,
+    /// `p`: first prime factor of `n`.
+    pub prime1: Cow<'a, [u8]>,
+    /// `q`: Second prime factor of `n`.
+    pub prime2: Cow<'a, [u8]>,
+    /// Comment.
+    pub comment: Cow<'a, [u8]>,
+}
+
+impl<'a> SshRead<'a> for RsaPrivateKey<'a> {
+    fn read_ssh(pos: &mut Position<'a>) -> Result<Self> {
+        Ok(Self {
+            // Note the field order.
+            public_key: RsaPublicKey {
+                modulus: Cow::Borrowed(pos.read_mpint()?),
+                public_exponent: Cow::Borrowed(pos.read_mpint()?),
+            },
+            private_exponent: Cow::Borrowed(pos.read_mpint()?),
+            coefficient: Cow::Borrowed(pos.read_mpint()?),
+            prime1: Cow::Borrowed(pos.read_mpint()?),
+            prime2: Cow::Borrowed(pos.read_mpint()?),
+            comment: Cow::Borrowed(pos.read_string()?),
+        })
+    }
+}
+
+impl SshWrite for RsaPrivateKey<'_> {
+    fn write_ssh<E: Encoding + ?Sized>(&self, encoder: &mut E) {
+        // Note the field order.
+        encoder.extend_ssh_mpint(&self.public_key.modulus);
+        encoder.extend_ssh_mpint(&self.public_key.public_exponent);
+        encoder.extend_ssh_mpint(&self.private_exponent);
+        encoder.extend_ssh_mpint(&self.coefficient);
+        encoder.extend_ssh_mpint(&self.prime1);
+        encoder.extend_ssh_mpint(&self.prime2);
+        encoder.extend_ssh_string(&self.comment);
+    }
+}

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -672,9 +672,6 @@ impl Session {
                             match r.read_string() {
                                 Ok(key) => {
                                     let key2 = <&[u8]>::clone(&key);
-                                    #[cfg(not(feature = "openssl"))]
-                                    let key = parse_public_key(key).map_err(crate::Error::from);
-                                    #[cfg(feature = "openssl")]
                                     let key =
                                         parse_public_key(key, None).map_err(crate::Error::from);
                                     match key {

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -47,7 +47,6 @@ use futures::Future;
 use log::{debug, error, info, trace};
 use russh_cryptovec::CryptoVec;
 use russh_keys::encoding::Reader;
-#[cfg(feature = "openssl")]
 use russh_keys::key::SignatureHash;
 use russh_keys::key::{self, parse_public_key, PublicKey};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadHalf, WriteHalf};
@@ -1212,7 +1211,6 @@ impl KexDhDone {
         let pubkey = reader.read_string().map_err(crate::Error::from)?; // server public key.
         let pubkey = parse_public_key(
             pubkey,
-            #[cfg(feature = "openssl")]
             SignatureHash::from_rsa_hostkey_algo(self.names.key.0.as_bytes()),
         )
         .map_err(crate::Error::from)?;

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -102,9 +102,7 @@ impl Preferred {
             key::ED25519,
             key::ECDSA_SHA2_NISTP256,
             key::ECDSA_SHA2_NISTP521,
-            #[cfg(feature = "openssl")]
             key::RSA_SHA2_256,
-            #[cfg(feature = "openssl")]
             key::RSA_SHA2_512,
         ],
         cipher: CIPHER_ORDER,
@@ -140,14 +138,12 @@ impl Named for () {
 }
 
 use russh_keys::key::ED25519;
-#[cfg(feature = "openssl")]
 use russh_keys::key::SSH_RSA;
 
 impl Named for PublicKey {
     fn name(&self) -> &'static str {
         match self {
             PublicKey::Ed25519(_) => ED25519.0,
-            #[cfg(feature = "openssl")]
             PublicKey::RSA { .. } => SSH_RSA.0,
             PublicKey::EC { ref key } => key.algorithm(),
         }
@@ -158,7 +154,6 @@ impl Named for KeyPair {
     fn name(&self) -> &'static str {
         match self {
             KeyPair::Ed25519 { .. } => ED25519.0,
-            #[cfg(feature = "openssl")]
             KeyPair::RSA { ref hash, .. } => hash.name().0,
             KeyPair::EC { ref key } => key.algorithm(),
         }


### PR DESCRIPTION
* SSH encoding of RSA keys is moved into `protocol` module.
* Decouple the SSH encoding into traits.
* When `openssl` feature is not enabled, the pure-rust RSA impl is used.

Alternative implementation for https://github.com/warp-tech/russh/issues/225
