### PR TITLE
Fix hardcoded public key auth negotiation

### DIFF
--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -138,13 +138,12 @@ impl Named for () {
 }
 
 use russh_keys::key::ED25519;
-use russh_keys::key::SSH_RSA;
 
 impl Named for PublicKey {
     fn name(&self) -> &'static str {
         match self {
             PublicKey::Ed25519(_) => ED25519.0,
-            PublicKey::RSA { .. } => SSH_RSA.0,
+            PublicKey::RSA { ref hash, .. } => hash.name().0,
             PublicKey::EC { ref key } => key.algorithm(),
         }
     }


### PR DESCRIPTION
Authentication using RSA public keys was incorrectly hardcoded to use `ssh-rsa`, i.e., SHA1. This led to public keys set up to use `rsa-sha2-256` or `rsa-sha2-512` falling back to `ssh-rsa` and being rejected by modern SSH servers that are configured not to support SHA1 by default.

The solution derives the hash name from the public key instead of hardcoding it.