### PR TITLE
Implement `-cbc` ciphers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Russh
+
 [![Rust](https://github.com/warp-tech/russh/actions/workflows/rust.yml/badge.svg)](https://github.com/warp-tech/russh/actions/workflows/rust.yml)  <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-34-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
@@ -22,6 +23,9 @@ This is a fork of [Thrussh](https://nest.pijul.com/pijul/thrussh) by Pierre-Éti
   * `aes256-ctr` ✨
   * `aes192-ctr` ✨
   * `aes128-ctr` ✨
+  * `aes256-cbc` ✨
+  * `aes192-cbc` ✨
+  * `aes128-cbc` ✨
 * Key exchanges:
   * `curve25519-sha256@libssh.org`
   * `diffie-hellman-group1-sha1` ✨

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -20,7 +20,7 @@ vendored-openssl = ["openssl/vendored", "russh-keys/vendored-openssl"]
 [dependencies]
 aes = { workspace = true }
 aes-gcm = "0.10"
-cbc = { version = "0.1.2" }
+cbc = { version = "0.1" }
 async-trait = { workspace = true }
 bitflags = "2.0"
 byteorder = { workspace = true }

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -20,6 +20,7 @@ vendored-openssl = ["openssl/vendored", "russh-keys/vendored-openssl"]
 [dependencies]
 aes = { workspace = true }
 aes-gcm = "0.10"
+cbc = { version = "0.1.2" }
 async-trait = { workspace = true }
 bitflags = "2.0"
 byteorder = { workspace = true }

--- a/russh/src/cipher/block.rs
+++ b/russh/src/cipher/block.rs
@@ -11,19 +11,18 @@
 // limitations under the License.
 //
 
-use std::marker::PhantomData;
-
 use aes::cipher::{IvSizeUser, KeyIvInit, KeySizeUser, StreamCipher};
 use generic_array::GenericArray;
 use rand::RngCore;
+use std::marker::PhantomData;
 
 use super::super::Error;
 use super::PACKET_LENGTH_LEN;
 use crate::mac::{Mac, MacAlgorithm};
 
-pub struct SshBlockCipher<C: StreamCipher + KeySizeUser + IvSizeUser>(pub PhantomData<C>);
+pub struct SshBlockCipher<C: BlockStreamCipher + KeySizeUser + IvSizeUser>(pub PhantomData<C>);
 
-impl<C: StreamCipher + KeySizeUser + IvSizeUser + KeyIvInit + Send + 'static> super::Cipher
+impl<C: BlockStreamCipher + KeySizeUser + IvSizeUser + KeyIvInit + Send + 'static> super::Cipher
     for SshBlockCipher<C>
 {
     fn key_len(&self) -> usize {
@@ -73,29 +72,52 @@ impl<C: StreamCipher + KeySizeUser + IvSizeUser + KeyIvInit + Send + 'static> su
     }
 }
 
-pub struct OpeningKey<C: StreamCipher + KeySizeUser + IvSizeUser> {
-    cipher: C,
-    mac: Box<dyn Mac + Send>,
+pub struct OpeningKey<C: BlockStreamCipher> {
+    pub(crate) cipher: C,
+    pub(crate) mac: Box<dyn Mac + Send>,
 }
 
-pub struct SealingKey<C: StreamCipher + KeySizeUser + IvSizeUser> {
-    cipher: C,
-    mac: Box<dyn Mac + Send>,
+pub struct SealingKey<C: BlockStreamCipher> {
+    pub(crate) cipher: C,
+    pub(crate) mac: Box<dyn Mac + Send>,
 }
 
-impl<C: StreamCipher + KeySizeUser + IvSizeUser> super::OpeningKey for OpeningKey<C> {
+impl<C: BlockStreamCipher + KeySizeUser + IvSizeUser> super::OpeningKey for OpeningKey<C> {
+    fn packet_length_to_read_for_block_length(&self) -> usize {
+        16
+    }
+
     fn decrypt_packet_length(
         &self,
         _sequence_number: u32,
-        mut encrypted_packet_length: [u8; 4],
+        encrypted_packet_length: &[u8],
     ) -> [u8; 4] {
+        let mut first_block = [0u8; 16];
+        // Fine because of self.packet_length_to_read_for_block_length()
+        #[allow(clippy::indexing_slicing)]
+        first_block.copy_from_slice(&encrypted_packet_length[..16]);
+
         if self.mac.is_etm() {
-            encrypted_packet_length
+            // Fine because of self.packet_length_to_read_for_block_length()
+            #[allow(clippy::indexing_slicing)]
+            [
+                encrypted_packet_length[0],
+                encrypted_packet_length[1],
+                encrypted_packet_length[2],
+                encrypted_packet_length[3],
+            ]
         } else {
             // Work around uncloneable Aes<>
             let mut cipher: C = unsafe { std::ptr::read(&self.cipher as *const C) };
-            cipher.apply_keystream(&mut encrypted_packet_length);
-            encrypted_packet_length
+
+            cipher.decrypt_data(&mut first_block);
+
+            [
+                first_block[0],
+                first_block[1],
+                first_block[2],
+                first_block[3],
+            ]
         }
     }
 
@@ -118,9 +140,9 @@ impl<C: StreamCipher + KeySizeUser + IvSizeUser> super::OpeningKey for OpeningKe
             }
             #[allow(clippy::indexing_slicing)]
             self.cipher
-                .apply_keystream(&mut ciphertext_in_plaintext_out[PACKET_LENGTH_LEN..]);
+                .decrypt_data(&mut ciphertext_in_plaintext_out[PACKET_LENGTH_LEN..]);
         } else {
-            self.cipher.apply_keystream(ciphertext_in_plaintext_out);
+            self.cipher.decrypt_data(ciphertext_in_plaintext_out);
 
             if !self
                 .mac
@@ -135,7 +157,7 @@ impl<C: StreamCipher + KeySizeUser + IvSizeUser> super::OpeningKey for OpeningKe
     }
 }
 
-impl<C: StreamCipher + KeySizeUser + IvSizeUser> super::SealingKey for SealingKey<C> {
+impl<C: BlockStreamCipher + KeySizeUser + IvSizeUser> super::SealingKey for SealingKey<C> {
     fn padding_length(&self, payload: &[u8]) -> usize {
         let block_size = 16;
 
@@ -176,13 +198,28 @@ impl<C: StreamCipher + KeySizeUser + IvSizeUser> super::SealingKey for SealingKe
         if self.mac.is_etm() {
             #[allow(clippy::indexing_slicing)]
             self.cipher
-                .apply_keystream(&mut plaintext_in_ciphertext_out[PACKET_LENGTH_LEN..]);
+                .encrypt_data(&mut plaintext_in_ciphertext_out[PACKET_LENGTH_LEN..]);
             self.mac
                 .compute(sequence_number, plaintext_in_ciphertext_out, tag_out);
         } else {
             self.mac
                 .compute(sequence_number, plaintext_in_ciphertext_out, tag_out);
-            self.cipher.apply_keystream(plaintext_in_ciphertext_out);
+            self.cipher.encrypt_data(plaintext_in_ciphertext_out);
         }
+    }
+}
+
+pub trait BlockStreamCipher {
+    fn encrypt_data(&mut self, data: &mut [u8]);
+    fn decrypt_data(&mut self, data: &mut [u8]);
+}
+
+impl<T: StreamCipher> BlockStreamCipher for T {
+    fn encrypt_data(&mut self, data: &mut [u8]) {
+        self.apply_keystream(data);
+    }
+
+    fn decrypt_data(&mut self, data: &mut [u8]) {
+        self.apply_keystream(data);
     }
 }

--- a/russh/src/cipher/cbc.rs
+++ b/russh/src/cipher/cbc.rs
@@ -1,0 +1,53 @@
+use aes::cipher::{
+    BlockCipher, BlockDecrypt, BlockDecryptMut, BlockEncrypt, BlockEncryptMut, InnerIvInit, Iv,
+    IvSizeUser,
+};
+use cbc::{Decryptor, Encryptor};
+use digest::crypto_common::InnerUser;
+use generic_array::GenericArray;
+
+use super::block::BlockStreamCipher;
+
+pub struct CbcWrapper<C: BlockEncrypt + BlockCipher + BlockDecrypt> {
+    encryptor: Encryptor<C>,
+    decryptor: Decryptor<C>,
+}
+
+impl<C: BlockEncrypt + BlockCipher + BlockDecrypt> InnerUser for CbcWrapper<C> {
+    type Inner = C;
+}
+
+impl<C: BlockEncrypt + BlockCipher + BlockDecrypt> IvSizeUser for CbcWrapper<C> {
+    type IvSize = C::BlockSize;
+}
+
+impl<C: BlockEncrypt + BlockCipher + BlockDecrypt> BlockStreamCipher for CbcWrapper<C> {
+    fn encrypt_data(&mut self, data: &mut [u8]) {
+        for chunk in data.chunks_exact_mut(C::block_size()) {
+            let mut block: GenericArray<u8, _> = GenericArray::clone_from_slice(chunk);
+            self.encryptor.encrypt_block_mut(&mut block);
+            chunk.clone_from_slice(&block);
+        }
+    }
+
+    fn decrypt_data(&mut self, data: &mut [u8]) {
+        for chunk in data.chunks_exact_mut(C::block_size()) {
+            let mut block = GenericArray::clone_from_slice(chunk);
+            self.decryptor.decrypt_block_mut(&mut block);
+            chunk.clone_from_slice(&block);
+        }
+    }
+}
+
+impl<C: BlockEncrypt + BlockCipher + BlockDecrypt + Clone> InnerIvInit for CbcWrapper<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    #[inline]
+    fn inner_iv_init(cipher: C, iv: &Iv<Self>) -> Self {
+        Self {
+            encryptor: Encryptor::inner_iv_init(cipher.clone(), iv),
+            decryptor: Decryptor::inner_iv_init(cipher, iv),
+        }
+    }
+}

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -22,6 +22,7 @@ use chacha20::{ChaCha20Legacy, ChaCha20LegacyCore};
 use generic_array::typenum::{Unsigned, U16, U32, U8};
 use generic_array::GenericArray;
 use poly1305::Poly1305;
+use std::convert::TryInto;
 use subtle::ConstantTimeEq;
 
 use super::super::Error;
@@ -97,13 +98,8 @@ impl super::OpeningKey for OpeningKey {
         encrypted_packet_length: &[u8],
     ) -> [u8; 4] {
         // Fine because of self.packet_length_to_read_for_block_length()
-        #[allow(clippy::indexing_slicing)]
-        let mut encrypted_packet_length = [
-            encrypted_packet_length[0],
-            encrypted_packet_length[1],
-            encrypted_packet_length[2],
-            encrypted_packet_length[3],
-        ];
+        #[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+        let mut encrypted_packet_length: [u8; 4] = encrypted_packet_length.try_into().unwrap();
 
         let nonce = make_counter(sequence_number);
         let mut cipher = ChaCha20Legacy::new(&self.k1, &nonce);

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -141,7 +141,7 @@ impl super::OpeningKey for OpeningKey {
 
 impl super::SealingKey for SealingKey {
     fn padding_length(&self, payload: &[u8]) -> usize {
-        let block_size = 16;
+        let block_size = 8;
         let extra_len = super::PACKET_LENGTH_LEN + super::PADDING_LENGTH_LEN;
         let padding_len = if payload.len() + extra_len <= super::MINIMUM_PACKET_LEN {
             super::MINIMUM_PACKET_LEN - payload.len() - super::PADDING_LENGTH_LEN

--- a/russh/src/cipher/clear.rs
+++ b/russh/src/cipher/clear.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //
 
+use std::convert::TryInto;
+
 use crate::mac::MacAlgorithm;
 use crate::Error;
 
@@ -50,13 +52,8 @@ impl super::Cipher for Clear {
 impl super::OpeningKey for Key {
     fn decrypt_packet_length(&self, _seqn: u32, packet_length: &[u8]) -> [u8; 4] {
         // Fine because of self.packet_length_to_read_for_block_length()
-        #[allow(clippy::indexing_slicing)]
-        [
-            packet_length[0],
-            packet_length[1],
-            packet_length[2],
-            packet_length[3],
-        ]
+        #[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+        packet_length.try_into().unwrap()
     }
 
     fn tag_len(&self) -> usize {

--- a/russh/src/cipher/clear.rs
+++ b/russh/src/cipher/clear.rs
@@ -48,8 +48,15 @@ impl super::Cipher for Clear {
 }
 
 impl super::OpeningKey for Key {
-    fn decrypt_packet_length(&self, _seqn: u32, packet_length: [u8; 4]) -> [u8; 4] {
-        packet_length
+    fn decrypt_packet_length(&self, _seqn: u32, packet_length: &[u8]) -> [u8; 4] {
+        // Fine because of self.packet_length_to_read_for_block_length()
+        #[allow(clippy::indexing_slicing)]
+        [
+            packet_length[0],
+            packet_length[1],
+            packet_length[2],
+            packet_length[3],
+        ]
     }
 
     fn tag_len(&self) -> usize {

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -97,9 +97,16 @@ impl super::OpeningKey for OpeningKey {
     fn decrypt_packet_length(
         &self,
         _sequence_number: u32,
-        encrypted_packet_length: [u8; 4],
+        encrypted_packet_length: &[u8],
     ) -> [u8; 4] {
-        encrypted_packet_length
+        // Fine because of self.packet_length_to_read_for_block_length()
+        #[allow(clippy::indexing_slicing)]
+        [
+            encrypted_packet_length[0],
+            encrypted_packet_length[1],
+            encrypted_packet_length[2],
+            encrypted_packet_length[3],
+        ]
     }
 
     fn tag_len(&self) -> usize {

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -15,6 +15,8 @@
 
 // http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD
 
+use std::convert::TryInto;
+
 use aes_gcm::{AeadCore, AeadInPlace, Aes256Gcm, KeyInit, KeySizeUser};
 use digest::typenum::Unsigned;
 use generic_array::GenericArray;
@@ -100,13 +102,8 @@ impl super::OpeningKey for OpeningKey {
         encrypted_packet_length: &[u8],
     ) -> [u8; 4] {
         // Fine because of self.packet_length_to_read_for_block_length()
-        #[allow(clippy::indexing_slicing)]
-        [
-            encrypted_packet_length[0],
-            encrypted_packet_length[1],
-            encrypted_packet_length[2],
-            encrypted_packet_length[3],
-        ]
+        #[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+        encrypted_packet_length.try_into().unwrap()
     }
 
     fn tag_len(&self) -> usize {


### PR DESCRIPTION
This PR addresses issues related to connecting to legacy Cisco devices with no upgrade path (similar to issue #277).

Changes Introduced

•	Refactored cipher/mod.rs: Make room to be able to implement CBC  crypto support.
•	Updated cipher/block.rs: To provide an interface compatible with both streaming ciphers and CBC.
•	General Cipher Updates: Light modifications to other ciphers for compatibility with the new interface.

Context

I had trouble connecting to older Cisco devices which posed challenges due to their outdated cryptographic support. 