### PR TITLE
Fix block ciphers + HMAC_SHA1_ETM

### DIFF
--- a/russh/src/mac/mod.rs
+++ b/russh/src/mac/mod.rs
@@ -74,7 +74,7 @@ static _HMAC_SHA256: CryptoMacAlgorithm<Hmac<Sha256>, U32> =
     CryptoMacAlgorithm(PhantomData, PhantomData);
 static _HMAC_SHA512: CryptoMacAlgorithm<Hmac<Sha512>, U64> =
     CryptoMacAlgorithm(PhantomData, PhantomData);
-static _HMAC_SHA1_ETM: CryptoEtmMacAlgorithm<Hmac<Sha1>, U64> =
+static _HMAC_SHA1_ETM: CryptoEtmMacAlgorithm<Hmac<Sha1>, U20> =
     CryptoEtmMacAlgorithm(PhantomData, PhantomData);
 static _HMAC_SHA256_ETM: CryptoEtmMacAlgorithm<Hmac<Sha256>, U32> =
     CryptoEtmMacAlgorithm(PhantomData, PhantomData);


### PR DESCRIPTION
Due to an incorrect specified array length, any combinaison of a cipher using `block.rs`and `HMAC_SHA1_ETM` such as:

```
let mut config = client::Config::default();
config.preferred.cipher = &[cipher::AES_128_CTR];
config.preferred.mac = &[mac::HMAC_SHA1_ETM];
```

Would fail during packet auth.

```
[...]
[2024-06-07T12:49:14Z DEBUG russh::cipher] reading, clear len = 276
[2024-06-07T12:49:14Z DEBUG russh::cipher] read_exact 280
[2024-06-07T12:49:14Z DEBUG russh::cipher] read_exact done
[2024-06-07T12:49:14Z TRACE russh::client] disconnected
[2024-06-07T12:49:14Z DEBUG russh::client] disconnected: Error(PacketAuth)
[2024-06-07T12:49:14Z TRACE mio::poll] deregistering event source from poller
[2024-06-07T12:49:14Z DEBUG russh::client] drop session
[2024-06-07T12:49:14Z DEBUG russh::client] drop handle
```

This PR fixes that.